### PR TITLE
Instruction tokeniser

### DIFF
--- a/assembler/src/classmap.php
+++ b/assembler/src/classmap.php
@@ -19,6 +19,7 @@ const CLASS_MAP = [
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\IntImmediate' => '/parser/effective_address/IntImmediate.php',
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\GPRIndirect' => '/parser/effective_address/GPRIndirect.php',
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\PCIndirectIndexed' => '/parser/effective_address/PCIndirectIndexed.php',
+  'ABadCafe\\MC64K\\Tokeniser\\Instruction' => '/tokeniser/Instruction.php',
   'ABadCafe\\MC64K\\Defs\\Register\\INames' => '/defs/register/INames.php',
   'ABadCafe\\MC64K\\Defs\\Register\\Enumerator' => '/defs/register/Enumerator.php',
   'ABadCafe\\MC64K\\Defs\\Mnemonic\\INames' => '/defs/mnemonic/INames.php',

--- a/assembler/src/tests/test_instruction_tokeniser
+++ b/assembler/src/tests/test_instruction_tokeniser
@@ -1,0 +1,39 @@
+#!/usr/bin/php -n
+<?php
+
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace ABadCafe\MC64K;
+
+require_once '../MC64K.php';
+
+const EXAMPLES = [
+    '.looptarget:', // expect null for this one
+    'jmp (a0)',
+    'add.b #1, r0',
+    'sub.w r0, r1',
+    'and.l r1, (r0)',
+    'beq.q (r0), (r1), label1',
+    'bgt.b (r1, r0.w), r0, label2',
+    'ble.q 4(r1), 4(r0, r2.w), label3',
+    'flog2.d (r0, r1.w * 2), 4(r0, r2.w)'
+];
+
+$oTokeniser = new Tokeniser\Instruction;
+
+foreach (EXAMPLES as $sInput) {
+    echo $sInput, " => ", print_r($oTokeniser->tokenise($sInput), true), "\n";
+}

--- a/assembler/src/tokeniser/Instruction.php
+++ b/assembler/src/tokeniser/Instruction.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+declare(strict_types = 1);
+
+namespace ABadCafe\MC64K\Tokeniser;
+
+/**
+ * Basic instruction tokeniser
+ */
+class Instruction {
+    const
+        MATCH            = '/^\s*([a-z2]+(?:\.[bwlqsd]){0,1})\s*(.*?)$/',
+        MATCH_INDIRECT   = '/\(.*?\)/',
+        MATCHED_MNEMONIC = 1,
+        MATCHED_OPERANDS = 2
+    ;
+
+    /**
+     * Tokenises an instruction statement of the form:
+     *
+     *   mnemonic[.size] operand1, operand2, ...
+     *
+     * The return is a structure containing a string field for the mnemonic and an array for the operands, in lexical order.
+     * If the input text could not be tokenised, null is returned.
+     *
+     * @param  string sInput
+     * @return object|null
+     */
+    public function tokenise(string $sInput) : ?object {
+        if (preg_match(self::MATCH, $sInput, $aMatches)) {
+            $sMnemonic = $aMatches[self::MATCHED_MNEMONIC];
+
+            // There is some complexity separating out the operands because they are comma separated while at the same time
+            // a comma can also be part of an operand, e.g. indexed addressing modes.
+            //
+            // To solve this, we first take the operand string and replace all indirect operands with placeholders, keeping
+            // track of the original operand text. We then split the remaining text on commas and for each element of the
+            // output, restore the original text.
+
+            $iPlaceholderKey = 0;
+            $aPlaceholderMap = [];
+            $sOperands = preg_replace_callback(
+                self::MATCH_INDIRECT,
+                function(array $aMatches) use (&$iPlaceholderKey, &$aPlaceholderMap) : string {
+                    $sKey = '(I:' . $iPlaceholderKey++ . ')';
+                    $aPlaceholderMap[$sKey] = $aMatches[0];
+                    return $sKey;
+                },
+                $aMatches[self::MATCHED_OPERANDS]
+            );
+
+            return (object)[
+                'sMnemonic' => $sMnemonic,
+                'aOperands' => array_map(
+                    function(string $sFragment) use (&$aPlaceholderMap) : string {
+                        return str_replace(
+                            array_keys($aPlaceholderMap),
+                            array_values($aPlaceholderMap),
+                            trim($sFragment)
+                        );
+                    },
+                    explode(',', $sOperands)
+                )
+            ];
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Simple class to take a line of source text that may (or may not) contain an instruction or instruction-like directive and break it down into a parseable mnemonic with operands.