### PR TITLE
Bugfix for define directive

### DIFF
--- a/assembler/src/parser/source_line/directive/Statement.php
+++ b/assembler/src/parser/source_line/directive/Statement.php
@@ -29,7 +29,7 @@ use function \preg_match, \strtolower;
  */
 class Statement implements SourceLine\IParser {
 
-    const
+    private const
         BASIC_LINE_MATCH = '/^\s+@([a-zA-Z_]+)\s+/'
     ;
 

--- a/assembler/src/parser/source_line/directive/processor/Define.php
+++ b/assembler/src/parser/source_line/directive/processor/Define.php
@@ -32,7 +32,7 @@ use function \preg_match, \rtrim;
  */
 class Define implements Directive\IProcessor {
 
-    const
+    private const
         EXTRACT_MATCH = '/^\s+@(def|define|equ)\s+([a-zA-Z_]{1}[a-zA-Z0-9_]*)\s+(.*)/',
         KEYWORDS      = [
             'def',
@@ -53,7 +53,7 @@ class Define implements Directive\IProcessor {
      */
     public function process(string $sSource): void {
         preg_match(self::EXTRACT_MATCH, rtrim($sSource), $aMatches);
-        if (!empty($aMatches[2]) && !empty($aMatches[3])) {
+        if (!empty($aMatches[2]) && isset($aMatches[3])) {
             State\Coordinator::get()
                 ->getDefinitionSet()
                 ->add($aMatches[2], $aMatches[3]);

--- a/assembler/src/parser/source_line/directive/processor/Export.php
+++ b/assembler/src/parser/source_line/directive/processor/Export.php
@@ -31,7 +31,7 @@ use function \preg_match, \rtrim;
  */
 class Export implements Directive\IProcessor {
 
-    const
+    private const
         EXTRACT_MATCH = '/^\s+@export\s+(' . Defs\ILabel::BASIC_MATCH . ')' . Defs\ILabel::IE_SUFFIX_MATCH . '/',
         KEYWORDS      = [
             'export'

--- a/assembler/src/parser/source_line/directive/processor/Flag.php
+++ b/assembler/src/parser/source_line/directive/processor/Flag.php
@@ -29,7 +29,7 @@ use function \preg_match, \rtrim;
  */
 class Flag implements Directive\IProcessor {
 
-    const
+    private const
         EXTRACT_MATCH = '/^\s+@(en|dis)(?:able){0,1}\s+([a-zA-Z0-9_]+)/',
         KEYWORDS      = [
             'en',

--- a/assembler/src/parser/source_line/directive/processor/Import.php
+++ b/assembler/src/parser/source_line/directive/processor/Import.php
@@ -29,7 +29,7 @@ use function \preg_match, \rtrim;
  */
 class Import implements Directive\IProcessor {
 
-    const
+    private const
         EXTRACT_MATCH = '/^\s+@import\s+(' . Defs\ILabel::BASIC_MATCH .  ')' . Defs\ILabel::IE_SUFFIX_MATCH . '/',
         KEYWORDS      = [
             'import'

--- a/assembler/src/parser/source_line/directive/processor/Undefine.php
+++ b/assembler/src/parser/source_line/directive/processor/Undefine.php
@@ -34,7 +34,7 @@ use function \preg_match, \rtrim;
  */
 class Undefine implements Directive\IProcessor {
 
-    const
+    private const
         EXTRACT_MATCH = '/^\s+@(?:undef|undefine)\s+([a-zA-Z_]{1}[a-zA-Z0-9_]*)/',
         KEYWORDS      = [
             'undef',

--- a/assembler/src/parser/source_line/instruction/operand/BranchDisplacement.php
+++ b/assembler/src/parser/source_line/instruction/operand/BranchDisplacement.php
@@ -32,13 +32,10 @@ use function \preg_match, \pack;
  */
 class BranchDisplacement implements MC64K\IParser {
 
-    const
-        MATCH_NUMERIC = '/^#' . Parser\EffectiveAddress\IParser::D32 . '$/',
+    private const
         MATCH_LABEL   = '/^(\.){0,1}[a-zA-Z_]{1}[0-9a-zA-Z_]{0,}$/',
         MATCHED_LABEL = 0,
-        MATCHED_LOCAL = 1,
-        MATCHED_DISP  = 1,
-        MATCHED_HEX   = 2
+        MATCHED_LOCAL = 1
     ;
 
     private int $iLastDisplacement = Defs\IBranchLimits::UNRESOLVED_DISPLACEMENT;

--- a/assembler/src/state/DefinitionSet.php
+++ b/assembler/src/state/DefinitionSet.php
@@ -102,4 +102,9 @@ class DefinitionSet {
         $aDefinitions = $this->getDefinitions();
         return str_replace(array_keys($aDefinitions), array_values($aDefinitions), $sInput);
     }
+
+    public function debug() {
+        print_r($this->aDefinitions);
+        return $this;
+    }
 }


### PR DESCRIPTION
Identified defect in the define declatation that prevented the addition of definitions equating to zero.