### PR TITLE
Adding build options

### DIFF
--- a/core/src/cpp/Makefile.x64_linux
+++ b/core/src/cpp/Makefile.x64_linux
@@ -5,7 +5,7 @@ BIN      = bin/interpreter_x64
 
 
 # Compiler settings
-CXXFLAGS = -Wall -Werror -Ofast -march=native -mtune=native -mavx2 -fPIC -pipe -Iinclude
+CXXFLAGS = -Wall -Werror -Ofast -march=native -mtune=native -mavx2 -fPIC -pipe -Iinclude -DALLOW_MISALIGNED_IMMEDIATE -DUSE_GLOBAL_REGISTER
 GCC_CXXFLAGS = -fwhole-program -flto -fexpensive-optimizations -funroll-all-loops -DMESSAGE='"Compiled with GCC"'
 CLANG_CXXFLAGS = -v -funroll-loops -DMESSAGE='"Compiled with Clang"'
 UNKNOWN_CXXFLAGS = -DMESSAGE='"Compiled with an unknown compiler"'

--- a/core/src/cpp/include/machine/gnarly.hpp
+++ b/core/src/cpp/include/machine/gnarly.hpp
@@ -32,11 +32,17 @@
 /**
  * Reads a 4 byte displacement value from the opcode stream into the initialised temporary.
  */
+#ifdef ALLOW_MISALIGNED_IMMEDIATE
+#define readDisplacement() \
+    iDisplacement = *((int32*)puProgramCounter); puProgramCounter+=4;
+
+#else
 #define readDisplacement() \
     auBytes[0] = *puProgramCounter++; \
     auBytes[1] = *puProgramCounter++; \
     auBytes[2] = *puProgramCounter++; \
     auBytes[3] = *puProgramCounter++;
+#endif
 
 /**
  * Alias of readDisplacment() for when the value represents a mask value and not a displacement.

--- a/core/src/cpp/machine/interpreter.cpp
+++ b/core/src/cpp/machine/interpreter.cpp
@@ -23,7 +23,11 @@
 namespace MC64K {
 namespace Machine {
 
+#ifdef USE_GLOBAL_REGISTER
 register uint8 const* puProgramCounter __asm__("r12");
+#else
+uint8 const* puProgramCounter;
+#endif
 
 GPRegister      Interpreter::aoGPR[GPRegister::MAX] = {};
 FPRegister      Interpreter::aoFPR[FPRegister::MAX] = {};

--- a/core/src/cpp/machine/interpreter_ea.cpp
+++ b/core/src/cpp/machine/interpreter_ea.cpp
@@ -28,6 +28,7 @@ namespace {
         float64 fDouble;
         float32 fSingle;
         int64   iQuad;
+        int32   iLong;
         uint8   auBytes[8];
     } oImmediate;
 }
@@ -143,14 +144,26 @@ void* Interpreter::decodeEffectiveAddress() {
                 case EffectiveAddress::Other::INT_IMM_LONG:
                 case EffectiveAddress::Other::FLT_IMM_SINGLE:
                     oImmediate.iQuad = (int8)puProgramCounter[3];
+
+                #ifdef ALLOW_MISALIGNED_IMMEDIATE
+                    oImmediate.iLong = *(int32*)puProgramCounter;
+                    puProgramCounter += 4;
+                #else
                     oImmediate.auBytes[0] = *puProgramCounter++;
                     oImmediate.auBytes[1] = *puProgramCounter++;
                     oImmediate.auBytes[2] = *puProgramCounter++;
                     oImmediate.auBytes[3] = *puProgramCounter++;
+                #endif
+
                     return &oImmediate.iQuad;
 
                 case EffectiveAddress::Other::INT_IMM_QUAD:
                 case EffectiveAddress::Other::FLT_IMM_DOUBLE:
+
+                #ifdef ALLOW_MISALIGNED_IMMEDIATE
+                    oImmediate.iQuad = *(int64*)puProgramCounter;
+                    puProgramCounter += 8;
+                #else
                     oImmediate.auBytes[0] = *puProgramCounter++;
                     oImmediate.auBytes[1] = *puProgramCounter++;
                     oImmediate.auBytes[2] = *puProgramCounter++;
@@ -159,6 +172,8 @@ void* Interpreter::decodeEffectiveAddress() {
                     oImmediate.auBytes[5] = *puProgramCounter++;
                     oImmediate.auBytes[6] = *puProgramCounter++;
                     oImmediate.auBytes[7] = *puProgramCounter++;
+                #endif
+
                     return &oImmediate.iQuad;
 
                 case EffectiveAddress::Other::PC_IND_DSP:


### PR DESCRIPTION
Put some controversial options behind build flags:

- ALLOW_MISALIGNED_IMMEDIATE
    - When set, allows reading of immediate data from the instruction stream as the appropriate 32 or 64 bit value even if this would result in a misaligned data access.
- USE_GLOBAL_REGISTER
    - When set, attempts to reserve caller saved register globals for holding key interpreter properties.