### PR TITLE
Feature/assembler

### DIFF
--- a/assembler/createclassap
+++ b/assembler/createclassap
@@ -40,11 +40,14 @@ class ClassMapBuilder {
      * Main entry point
      *
      * @param string $sSourceDir
+     * @param string $sNameSpace
+     * @param bool   $bCheckNSOptimisation
      */
-    public function execute(string $sSourceDir, string $sNameSpace) {
+    public function execute(string $sSourceDir, string $sNameSpace, bool $bCheckNSOptimisation): void {
         $this->aFiles = [];
         $this->traverse($sSourceDir);
         $this->aClassMap = [];
+        echo "Building classmap...\n";
         foreach ($this->aFiles as $sSourcePath) {
             $this->processFile($sSourcePath);
         }
@@ -53,10 +56,13 @@ class ClassMapBuilder {
             ";";
         file_put_contents('src/classmap.php', $sCode);
 
-        foreach ($this->aFiles as $sFile) {
-            $sTest = shell_exec('php -dvld.active=1 -dvld.execute=0 ' . $sFile . ' 2>&1 | grep INIT_NS');
-            if (!empty($sTest)) {
-                echo $sFile, ":\n", $sTest, "\n";
+        if ($bCheckNSOptimisation) {
+            echo "Testing for global functions accessed within namespace...\n";
+            foreach ($this->aFiles as $sFile) {
+                $sTest = shell_exec('php -dvld.active=1 -dvld.execute=0 ' . $sFile . ' 2>&1 | grep INIT_NS');
+                if (!empty($sTest)) {
+                    echo $sFile, ":\n", $sTest, "\n";
+                }
             }
         }
     }
@@ -110,4 +116,6 @@ class ClassMapBuilder {
     }
 }
 
-(new ClassMapBuilder)->execute('src/', 'ABadCafe\MC64K');
+$bCheckNSOptimisation = isset($_SERVER['argv'][1]);
+
+(new ClassMapBuilder)->execute('src/', 'ABadCafe\MC64K', $bCheckNSOptimisation);

--- a/assembler/src/state/DefinitionSet.php
+++ b/assembler/src/state/DefinitionSet.php
@@ -17,7 +17,7 @@ declare(strict_types = 1);
 
 namespace ABadCafe\MC64K\State;
 
-use function \strlen, \uasort, \str_replace, \array_keys, \array_values;
+use function \strlen, \uasort, \str_replace, \array_keys, \array_values, \preg_replace_callback;
 
 /**
  * DefinitionSet
@@ -85,7 +85,7 @@ class DefinitionSet {
     }
 
     /**
-     * Apply the corrent definition set to a string performing a set of search and replace terms.
+     * Apply the current definition set to a string performing a set of search and replace terms.
      *
      * @todo This needs doing properly. The current implementation is a dumb search and replace that is not
      * sensible - it will result in later search terms overwriting earlier ones. What we should do is to
@@ -99,7 +99,22 @@ class DefinitionSet {
         if (empty($this->aDefinitions)) {
             return $sInput;
         }
+
+        // Protect any string literals or labels
+        $iPlaceholderKey = 0;
+        $aPlaceholderMap = [];
+        $sInput = preg_replace_callback(
+            '/".*?"|[a-zA-Z0-9_]+\:$/',
+            function(array $aMatches) use (&$iPlaceholderKey, &$aPlaceholderMap): string {
+                $sKey = '{S:' . $iPlaceholderKey++ . '}';
+                $aPlaceholderMap[$sKey] = $aMatches[0];
+                return $sKey;
+            },
+            $sInput
+        );
+
         $aDefinitions = $this->getDefinitions();
+        $aDefinitions += $aPlaceholderMap;
         return str_replace(array_keys($aDefinitions), array_values($aDefinitions), $sInput);
     }
 }

--- a/assembler/src/state/LabelLocation.php
+++ b/assembler/src/state/LabelLocation.php
@@ -445,11 +445,20 @@ class LabelLocation {
      * Asserts if a label is valid. For now this is just a length check.
      *
      * @param   string $sLabel
-     * @@throws \LengthException
+     * @@throws \LengthException|\InvalidArgumentException
      */
     private function assertLabel(string $sLabel): void {
         if (strlen($sLabel) > Defs\ILabel::MAX_LENGTH) {
-            throw new \LengthException();
+            throw new \LengthException("Label identifer '" . $sLabel . "' too long");
+        }
+        if (
+            isset(Defs\Register\INames::GPR_MAP[$sLabel]) ||
+            isset(Defs\Register\INames::FPR_MAP[$sLabel])
+        ) {
+            throw new \InvalidArgumentException(
+                "Register name '" . $sLabel .
+                "' used in a context that expects a label"
+            );
         }
     }
 

--- a/assembler/src/state/LabelLocation.php
+++ b/assembler/src/state/LabelLocation.php
@@ -20,7 +20,7 @@ use ABadCafe\MC64K\Defs;
 use ABadCafe\MC64K\Utils\Log;
 use ABadCafe\MC64K\IO;
 
-use function \sprintf, \strlen, \array_flip, \str_split;
+use function \sprintf, \strlen, \array_flip, \str_split, \implode, \array_keys;
 
 /**
  * LabelLocation


### PR DESCRIPTION
* Register names marked as reserved so that they can't be conflated with labels in places that may otherwise interpret them that way, e.g. `fmoveq.d` 
* String literals and label names are no protected from the basic per line search and replace action of `@def` and `@equ` definitions.
* Other minor fixes.