### PR TITLE
Feature/full stack

### DIFF
--- a/assembler/libs/standard_test_host/v1.0.0/display.s
+++ b/assembler/libs/standard_test_host/v1.0.0/display.s
@@ -1,0 +1,20 @@
+
+;  888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+;  8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+;  88888b.d88888 888    888 888          d8P 888  888  d8P
+;  888Y88888P888 888        888d888b.   d8P  888  888d88K
+;  888 Y888P 888 888        888P "Y88b d88   888  8888888b
+;  888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+;  888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+;  888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+;
+;   - 64-bit 680x0-inspired Virtual Machine and assembler -
+;
+; Stub library for the standard test host IO routines
+
+
+    @def display_vector #3
+
+    @equ display_init     #0, display_vector
+    @equ display_done     #1, display_vector
+    @equ display_begin    #2, display_vector

--- a/assembler/test_projects/bench/src/bench_bsr_ret.s
+++ b/assembler/test_projects/bench/src/bench_bsr_ret.s
@@ -126,13 +126,13 @@ bench_bsr_ret:
     rts
 
 .benchmark_info:
-    dc.b "Benchmarking: bsr/ret\n\0"
+    dc.b "Benchmarking: bsr/rts\n\0"
 
 .benchmark_info_1:
-    dc.b "Benchmarking: bsr/ret (stack misaligned)\n\0"
+    dc.b "Benchmarking: bsr/rts (stack misaligned)\n\0"
 
 .benchmark_info_2:
-    dc.b "Benchmarking: bsr.b/ret (short negative displacement)\n\0"
+    dc.b "Benchmarking: bsr.b/rts (short negative displacement)\n\0"
 
 .benchmark_info_3:
-    dc.b "Benchmarking: bsr.b/ret (short negative displacement, stack misaligned)\n\0"
+    dc.b "Benchmarking: bsr.b/rts (short negative displacement, stack misaligned)\n\0"

--- a/assembler/test_projects/bench/src/main.s
+++ b/assembler/test_projects/bench/src/main.s
@@ -14,7 +14,7 @@
 
     @equ nanotime           dc.b 0xF0 ; super undocumented opcodes ftw
 
-    @equ max_loops          #20000000
+    @equ max_loops          #80000000
     @equ loop_scale         #10000 ; 10x unroll x 1000 for scale to MIPS from ops/ns
     @equ loop_counter       r2
     @equ time_recorded      r14
@@ -34,13 +34,13 @@ main:
     hcf         io_print_string
 
     bsr         calibration
-    ;bsr         bench_add_reg_to_indirect
-    ;bsr         bench_add_reg_ind_to_reg_ind
-    ;bsr         bench_add_reg_to_label
-    ;bsr         bench_add_label_to_label
-    ;bsr         bench_small_imm_to_reg
-    ;bsr         bench_biz_int_taken
-    ;bsr         bench_biz_int_not_taken
+    bsr         bench_add_reg_to_indirect
+    bsr         bench_add_reg_ind_to_reg_ind
+    bsr         bench_add_reg_to_label
+    bsr         bench_add_label_to_label
+    bsr         bench_small_imm_to_reg
+    bsr         bench_biz_int_taken
+    bsr         bench_biz_int_not_taken
     bsr         bench_bsr_ret
     bsr         bench_hcf
 

--- a/assembler/test_projects/display/bin/README.md
+++ b/assembler/test_projects/display/bin/README.md
@@ -1,0 +1,1 @@
+Build Location

--- a/assembler/test_projects/display/proj.json
+++ b/assembler/test_projects/display/proj.json
@@ -1,0 +1,26 @@
+{
+    "target": {
+        "name": "Display",
+        "version": "1.0.0",
+        "description": "Display Prototyping",
+        "output": "bin/display.64x",
+        "host": {
+            "name": "Standard Test Host",
+            "version": "1.0.0"
+        }
+    },
+    "options": {
+        "log_code_folds": false,
+        "log_label_add": false,
+        "log_label_ref": false,
+        "log_label_resolve": false
+    },
+    "sources": [
+        "lib:standard_test_host/v1.0.0/host.s",
+        "lib:standard_test_host/v1.0.0/io.s",
+        "lib:standard_test_host/v1.0.0/display.s",
+        "src/main.s"
+    ],
+    "defines": {
+    }
+}

--- a/assembler/test_projects/display/src/main.s
+++ b/assembler/test_projects/display/src/main.s
@@ -1,0 +1,44 @@
+
+;  888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+;  8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+;  88888b.d88888 888    888 888          d8P 888  888  d8P
+;  888Y88888P888 888        888d888b.   d8P  888  888d88K
+;  888 Y888P 888 888        888P "Y88b d88   888  8888888b
+;  888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+;  888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+;  888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+;
+;   - 64-bit 680x0-inspired Virtual Machine and assembler -
+;
+; Empty project - main.s
+
+main:
+    hcf     io_init
+    hcf     display_init
+
+    lea     on_frame, r8
+
+    hcf     display_begin
+
+    move.q  #0xabadcafe, r7
+
+    lea     .exit_message, r8
+    hcf     io_print_string
+
+exit:
+    move.q  #0xdeadbeef, r6
+    hcf     display_done
+    hcf     io_done
+    rts
+
+on_frame:
+    add.q   #1, r5
+    lea     .frame_message, r8
+    hcf     io_print_string
+    rts
+
+.frame_message:
+    dc.b "VM frame callback called\n\0"
+
+.exit_message:
+    dc.b "Exited from native loop\n\0"

--- a/core/src/cpp/assemblytest.cpp
+++ b/core/src/cpp/assemblytest.cpp
@@ -1,0 +1,39 @@
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+#include <cstdio>
+#include <machine/register.hpp>
+#include <machine/interpreter.hpp>
+
+using MC64K::Machine::Interpreter;
+
+namespace MC64K::AssemblyTest {
+
+void setGPR() {
+    Interpreter::gpr<0>().value<int8>()   = 0x11;
+    Interpreter::gpr<1>().value<uint8>()  = 0x22;
+    Interpreter::gpr<2>().value<int16>()  = 0x3333;
+    Interpreter::gpr<3>().value<uint16>() = 0x4444;
+    Interpreter::gpr<4>().value<int32>()  = 0x55555555;
+    Interpreter::gpr<5>().value<uint32>() = 0x55555555;
+    Interpreter::gpr<6>().value<int64>()  = 0x6666666666666666;
+    Interpreter::gpr<7>().value<uint64>() = 0x7777777777777777;
+}
+
+void setFPR() {
+    Interpreter::fpr<0>().value<float32>()  = 0.25;
+    Interpreter::fpr<1>().value<float64>()  = 0.125;
+}
+
+} // namespace
+

--- a/core/src/cpp/assemblytest.s
+++ b/core/src/cpp/assemblytest.s
@@ -1,0 +1,70 @@
+	.file	"assemblytest.cpp"
+# GNU C++17 (Ubuntu 11.1.0-1ubuntu1~18.04.1) version 11.1.0 (x86_64-linux-gnu)
+#	compiled by GNU C version 11.1.0, GMP version 6.1.2, MPFR version 4.0.1, MPC version 1.1.0, isl version isl-0.19-GMP
+
+# GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
+# options passed: -march=skylake -mmmx -mpopcnt -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mavx -mno-sse4a -mno-fma4 -mno-xop -mfma -mno-avx512f -mbmi -mbmi2 -maes -mpclmul -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-avx512er -mno-avx512pf -mno-avx512vbmi -mno-avx512ifma -mno-avx5124vnniw -mno-avx5124fmaps -mno-avx512vpopcntdq -mno-avx512vbmi2 -mno-gfni -mno-vpclmulqdq -mno-avx512vnni -mno-avx512bitalg -mno-avx512bf16 -mno-avx512vp2intersect -mno-3dnow -madx -mabm -mno-cldemote -mclflushopt -mno-clwb -mno-clzero -mcx16 -mno-enqcmd -mf16c -mfsgsbase -mfxsr -mno-hle -msahf -mno-lwp -mlzcnt -mmovbe -mno-movdir64b -mno-movdiri -mno-mwaitx -mno-pconfig -mno-pku -mno-prefetchwt1 -mprfchw -mno-ptwrite -mno-rdpid -mrdrnd -mrdseed -mno-rtm -mno-serialize -msgx -mno-sha -mno-shstk -mno-tbm -mno-tsxldtrk -mno-vaes -mno-waitpkg -mno-wbnoinvd -mxsave -mxsavec -mxsaveopt -mxsaves -mno-amx-tile -mno-amx-int8 -mno-amx-bf16 -mno-uintr -mno-hreset -mno-kl -mno-widekl -mno-avxvnni --param=l1-cache-size=32 --param=l1-cache-line-size=64 --param=l2-cache-size=4096 -mtune=skylake -mavx2 -Ofast -fPIC -fexpensive-optimizations -funroll-all-loops -fasynchronous-unwind-tables -fstack-protector-strong
+	.text
+	.p2align 4
+	.globl	_ZN5MC64K12AssemblyTest6setGPREv
+	.type	_ZN5MC64K12AssemblyTest6setGPREv, @function
+_ZN5MC64K12AssemblyTest6setGPREv:
+.LFB59:
+	.cfi_startproc
+# assemblytest.cpp:23:     Interpreter::gpr<0>().value<int8>()   = 0x11;
+	movq	_ZN5MC64K7Machine11Interpreter5aoGPRE@GOTPCREL(%rip), %rax	#, tmp82
+# assemblytest.cpp:25:     Interpreter::gpr<2>().value<int16>()  = 0x3333;
+	movl	$13107, %edx	#,
+# assemblytest.cpp:26:     Interpreter::gpr<3>().value<uint16>() = 0x4444;
+	movl	$17476, %ecx	#,
+# assemblytest.cpp:29:     Interpreter::gpr<6>().value<int64>()  = 0x6666666666666666;
+	movabsq	$7378697629483820646, %rsi	#, tmp93
+# assemblytest.cpp:30:     Interpreter::gpr<7>().value<uint64>() = 0x7777777777777777;
+	movabsq	$8608480567731124087, %rdi	#, tmp94
+# assemblytest.cpp:23:     Interpreter::gpr<0>().value<int8>()   = 0x11;
+	movb	$17, (%rax)	#, MEM[(signed char &)&aoGPR]
+# assemblytest.cpp:24:     Interpreter::gpr<1>().value<uint8>()  = 0x22;
+	movb	$34, 8(%rax)	#, MEM[(unsigned char &)&aoGPR + 8]
+# assemblytest.cpp:25:     Interpreter::gpr<2>().value<int16>()  = 0x3333;
+	movw	%dx, 16(%rax)	#, MEM[(short int &)&aoGPR + 16]
+# assemblytest.cpp:26:     Interpreter::gpr<3>().value<uint16>() = 0x4444;
+	movw	%cx, 24(%rax)	#, MEM[(short unsigned int &)&aoGPR + 24]
+# assemblytest.cpp:27:     Interpreter::gpr<4>().value<int32>()  = 0x55555555;
+	movl	$1431655765, 32(%rax)	#, MEM[(int &)&aoGPR + 32]
+# assemblytest.cpp:28:     Interpreter::gpr<5>().value<uint32>() = 0x55555555;
+	movl	$1431655765, 40(%rax)	#, MEM[(unsigned int &)&aoGPR + 40]
+# assemblytest.cpp:29:     Interpreter::gpr<6>().value<int64>()  = 0x6666666666666666;
+	movq	%rsi, 48(%rax)	# tmp93, MEM[(long int &)&aoGPR + 48]
+# assemblytest.cpp:30:     Interpreter::gpr<7>().value<uint64>() = 0x7777777777777777;
+	movq	%rdi, 56(%rax)	# tmp94, MEM[(long unsigned int &)&aoGPR + 56]
+# assemblytest.cpp:31: }
+	ret	
+	.cfi_endproc
+.LFE59:
+	.size	_ZN5MC64K12AssemblyTest6setGPREv, .-_ZN5MC64K12AssemblyTest6setGPREv
+	.p2align 4
+	.globl	_ZN5MC64K12AssemblyTest6setFPREv
+	.type	_ZN5MC64K12AssemblyTest6setFPREv, @function
+_ZN5MC64K12AssemblyTest6setFPREv:
+.LFB68:
+	.cfi_startproc
+# assemblytest.cpp:34:     Interpreter::fpr<0>().value<float32>()  = 0.25;
+	movq	_ZN5MC64K7Machine11Interpreter5aoFPRE@GOTPCREL(%rip), %rax	#, tmp82
+# assemblytest.cpp:35:     Interpreter::fpr<1>().value<float64>()  = 0.125;
+	movq	.LC1(%rip), %rdx	#, tmp87
+# assemblytest.cpp:34:     Interpreter::fpr<0>().value<float32>()  = 0.25;
+	movl	$0x3e800000, (%rax)	#, MEM[(float &)&aoFPR]
+# assemblytest.cpp:35:     Interpreter::fpr<1>().value<float64>()  = 0.125;
+	movq	%rdx, 8(%rax)	# tmp87, MEM[(double &)&aoFPR + 8]
+# assemblytest.cpp:36: }
+	ret	
+	.cfi_endproc
+.LFE68:
+	.size	_ZN5MC64K12AssemblyTest6setFPREv, .-_ZN5MC64K12AssemblyTest6setFPREv
+	.section	.rodata.cst8,"aM",@progbits,8
+	.align 8
+.LC1:
+	.long	0
+	.long	1069547520
+	.ident	"GCC: (Ubuntu 11.1.0-1ubuntu1~18.04.1) 11.1.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/core/src/cpp/host/definition.cpp
+++ b/core/src/cpp/host/definition.cpp
@@ -15,8 +15,8 @@
 #include <cstring>
 #include <cstdlib>
 #include <cassert>
-#include "host/definition.hpp"
-#include "machine/limits.hpp"
+#include <host/definition.hpp>
+#include <machine/limits.hpp>
 
 namespace MC64K::Host {
 

--- a/core/src/cpp/host/runtime.cpp
+++ b/core/src/cpp/host/runtime.cpp
@@ -15,8 +15,8 @@
 #include <cstring>
 #include <cstdlib>
 #include <cassert>
-#include "host/runtime.hpp"
-#include "loader/executable.hpp"
+#include <host/runtime.hpp>
+#include <loader/executable.hpp>
 
 namespace MC64K::Host {
 

--- a/core/src/cpp/host/standard_test_host_def.cpp
+++ b/core/src/cpp/host/standard_test_host_def.cpp
@@ -15,11 +15,12 @@
 #include <cmath>
 #include <cstdlib>
 
-#include "host/standard_test_host_io.hpp"
-#include "host/standard_test_host_mem.hpp"
-#include "host/standard_test_host_vector_math.hpp"
-#include "loader/symbol.hpp"
-#include "machine/register.hpp"
+#include <host/standard_test_host_io.hpp>
+#include <host/standard_test_host_mem.hpp>
+#include <host/standard_test_host_vector_math.hpp>
+#include <host/standard_test_host_display.hpp>
+#include <loader/symbol.hpp>
+#include <machine/register.hpp>
 
 using MC64K::Loader::Symbol;
 using MC64K::Machine::Interpreter;
@@ -53,7 +54,8 @@ Host::Definition instance(
     {
         IO::hostVector,
         Mem::hostVector,
-        VectorMath::hostVector
+        VectorMath::hostVector,
+        Display::hostVector
     },
 
     // Symbols this host exports to the virtual code.

--- a/core/src/cpp/host/standard_test_host_display.cpp
+++ b/core/src/cpp/host/standard_test_host_display.cpp
@@ -1,0 +1,67 @@
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <host/standard_test_host_display.hpp>
+#include <machine/register.hpp>
+
+using MC64K::Machine::Interpreter;
+
+namespace MC64K::StandardTestHost::Display {
+
+/**
+ * This is just a dummy proof of concept implementation for the moment. The idea will be that this will
+ * form the basis of a "swap display buffer and gather input" event loop from the host that invokes the
+ * user-supplied code address.
+ *
+ * TODO - The current mechanism is low latency as it just sets the PC and runs with it. We should probaby
+ * validate that the address matches a designated known function ID before allowing it to be called back to.
+ * This can be done before entering the loop.
+ */
+Interpreter::Status runEventLoop() {
+
+    uint8 const* volatile puFrameHookByteCode = Interpreter::gpr<ABI::PTR_REG_0>().address<uint8 const>();
+    if (puFrameHookByteCode) {
+        for (int i = 0; i < 100; ++i) {
+            Interpreter::setProgramCounter(puFrameHookByteCode);
+            Interpreter::run();
+        }
+        return Interpreter::INITIALISED;
+    }
+    return Interpreter::INVALID_ENTRYPOINT;
+}
+
+/**
+ * Display::hostVector(uint8 uFunctionID)
+ */
+Interpreter::Status hostVector(uint8 uFunctionID) {
+    Call iOperation = (Call) uFunctionID;
+    switch (iOperation) {
+        case INIT:
+        case DONE:
+            break;
+        case BEGIN:
+            return runEventLoop();
+            break;
+        default:
+            std::fprintf(stderr, "Unknown Display operation %d\n", iOperation);
+            return Interpreter::UNKNOWN_HOST_CALL;
+            break;
+    }
+
+    return Interpreter::RUNNING;
+}
+
+} // namespace
+

--- a/core/src/cpp/host/standard_test_host_io.cpp
+++ b/core/src/cpp/host/standard_test_host_io.cpp
@@ -12,9 +12,9 @@
  */
 
 #include <cstdio>
-#include "host/standard_test_host_io.hpp"
-#include "machine/register.hpp"
-#include "host/io/inline.hpp"
+#include <host/standard_test_host_io.hpp>
+#include <machine/register.hpp>
+#include <host/io/inline.hpp>
 
 using MC64K::Machine::Interpreter;
 

--- a/core/src/cpp/host/standard_test_host_mem.cpp
+++ b/core/src/cpp/host/standard_test_host_mem.cpp
@@ -14,9 +14,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include "host/standard_test_host_mem.hpp"
-#include "machine/register.hpp"
-#include "host/mem/inline.hpp"
+#include <host/standard_test_host_mem.hpp>
+#include <machine/register.hpp>
+#include <host/mem/inline.hpp>
 
 using MC64K::Machine::Interpreter;
 

--- a/core/src/cpp/host/standard_test_host_vector_math.cpp
+++ b/core/src/cpp/host/standard_test_host_vector_math.cpp
@@ -13,13 +13,13 @@
 
 #include <cstdio>
 #include <cmath>
-#include "machine/register.hpp"
-#include "host/standard_test_host_vector_math.hpp"
-#include "host/vector/vec2.hpp"
-#include "host/vector/vec3.hpp"
-#include "host/vector/mat2x2.hpp"
-#include "host/vector/mat3x3.hpp"
-#include "host/vector/mat4x4.hpp"
+#include <machine/register.hpp>
+#include <host/standard_test_host_vector_math.hpp>
+#include <host/vector/vec2.hpp>
+#include <host/vector/vec3.hpp>
+#include <host/vector/mat2x2.hpp>
+#include <host/vector/mat3x3.hpp>
+#include <host/vector/mat4x4.hpp>
 
 using MC64K::Machine::Interpreter;
 

--- a/core/src/cpp/include/host/definition.hpp
+++ b/core/src/cpp/include/host/definition.hpp
@@ -14,10 +14,9 @@
  *    - 64-bit 680x0-inspired Virtual Machine and assembler -
  */
 #include <initializer_list>
-
-#include "machine/interpreter.hpp"
-#include "misc/version.hpp"
-#include "loader/symbol.hpp"
+#include <machine/interpreter.hpp>
+#include <misc/version.hpp>
+#include <loader/symbol.hpp>
 
 namespace MC64K::Host {
 

--- a/core/src/cpp/include/host/standard_test_host.hpp
+++ b/core/src/cpp/include/host/standard_test_host.hpp
@@ -27,15 +27,15 @@ namespace ABI {
 /**
  * Enumeration of entry points the host expects to find in the loaded binary.
  */
-typedef enum {
+enum EntryPoint {
     MAIN = 0,
     EXIT = 1
-} EntryPoint;
+};
 
 /**
  * ABI. Define the registers used for param/return before stack spillage
  */
-typedef enum {
+enum Register {
     // r0-r2 (d0-d2) reserved for the first 3 integer parameter/return
     INT_REG_0 = GPRegister::R0,
     INT_REG_1 = GPRegister::R1,
@@ -50,17 +50,16 @@ typedef enum {
     FLT_REG_0 = FPRegister::FP0,
     FLT_REG_1 = FPRegister::FP1,
     FLT_REG_2 = FPRegister::FP2,
-
-} Register;
+};
 
 /**
  * Common Error codes
  */
-typedef enum {
+enum Result {
     ERR_NONE = 0,
     ERR_NULL_PTR,
     ERR_BAD_SIZE,
-} Result;
+};
 
 } // namespace ABI
 

--- a/core/src/cpp/include/host/standard_test_host_display.hpp
+++ b/core/src/cpp/include/host/standard_test_host_display.hpp
@@ -1,5 +1,5 @@
-#ifndef __MC64K_LOADER_DEPENDENCY_HPP__
-#   define __MC64K_LOADER_DEPENDENCY_HPP__
+#ifndef __MC64K_STANDARD_TEST_HOST_DISPLAY_HPP__
+    #define __MC64K_STANDARD_TEST_HOST_DISPLAY_HPP__
 
 /**
  *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
@@ -14,20 +14,30 @@
  *    - 64-bit 680x0-inspired Virtual Machine and assembler -
  */
 
-#include <cstdio>
-#include <misc/version.hpp>
+#include "standard_test_host.hpp"
 
-namespace MC64K::Loader {
+namespace MC64K::StandardTestHost::Display {
 
 /**
- * Dependency
+ * Call
  *
- * Simple dependency data structure
+ * Enumeration of calls in the Mem namespace
  */
-struct Dependency {
-    Misc::Version oVersion;
-    char const*   sName;
+enum Call {
+    INIT = 0,
+    DONE,
+    BEGIN
 };
 
+/**
+ * Error return values
+ */
+enum Result {
+    ERR_NO_DISPLAY = 1000,
+};
+
+Interpreter::Status hostVector(uint8 uFunctionID);
+
 } // namespace
+
 #endif

--- a/core/src/cpp/include/host/standard_test_host_io.hpp
+++ b/core/src/cpp/include/host/standard_test_host_io.hpp
@@ -23,7 +23,7 @@ namespace MC64K::StandardTestHost::IO {
  *
  * Enumeration of calls in the IO namespace
  */
-typedef enum {
+enum Call {
     INIT = 0,
     DONE,
 
@@ -196,39 +196,39 @@ typedef enum {
      */
     CBUF_PARSE_SINGLE,
     CBUF_PARSE_DOUBLE,
-} Call;
+};
 
 /**
  * Allowed modes for file opening
  */
-typedef enum {
+enum Openmode {
     OPEN_READ = 0,
     OPEN_WRITE,
     OPEN_APPEND,
     OPEN_READ_UPDATE,
     OPEN_WRITE_UPDATE,
     OPEN_APPEND_UPDATE
-} OpenMode;
+};
 
 /**
  * Allowed modes for file opening
  */
-typedef enum {
+enum SeekMode {
     FROM_START = 0,
     FROM_CURRENT,
     FROM_END,
-} SeekMode;
+};
 
 
 /**
  * Error return values
  */
-typedef enum {
+enum Result {
     ERR_FILE = 200,
     ERR_OPEN,
     ERR_READ,
     ERR_WRITE,
-} Result;
+};
 
 Interpreter::Status hostVector(uint8 uFunctionID);
 

--- a/core/src/cpp/include/host/standard_test_host_mem.hpp
+++ b/core/src/cpp/include/host/standard_test_host_mem.hpp
@@ -23,7 +23,7 @@ namespace MC64K::StandardTestHost::Mem {
  *
  * Enumeration of calls in the Mem namespace
  */
-typedef enum {
+enum Call {
     INIT = 0,
     DONE,
 
@@ -86,15 +86,15 @@ typedef enum {
 
     STR_LENGTH,
     STR_COMPARE,
-} Call;
+};
 
 /**
  * Error return values
  */
-typedef enum {
+enum Result {
     ERR_NO_MEM = 100,
     ERR_MEM
-} Result;
+};
 
 Interpreter::Status hostVector(uint8 uFunctionID);
 

--- a/core/src/cpp/include/host/standard_test_host_vector_math.hpp
+++ b/core/src/cpp/include/host/standard_test_host_vector_math.hpp
@@ -53,7 +53,7 @@ namespace MC64K::StandardTestHost::VectorMath {
  * Enumeration of calls in the VectorMath namespace.
  *
  */
-typedef enum {
+enum Call {
     /**
      * Init and copy
      */
@@ -310,14 +310,14 @@ typedef enum {
     M4X4D_DET,          // fp0  = Determinant(a0)
     M4X4D_INVERSE,      // (a1) = Inverse(a0)
 
-} Call;
+};
 
 /**
  * Error return values
  */
-typedef enum {
+enum Result {
     ERR_ZERO_DIVIDE = 1000
-} Result;
+};
 
 
 Interpreter::Status hostVector(uint8 uFunctionID);

--- a/core/src/cpp/include/host/vector/vec2.hpp
+++ b/core/src/cpp/include/host/vector/vec2.hpp
@@ -16,7 +16,6 @@
 
 #include <cmath>
 #include <machine/register.hpp>
-#include <host/standard_test_host.hpp>
 #include "offsets.hpp"
 /**
  * 2D Vector Operations

--- a/core/src/cpp/include/host/vector/vec3.hpp
+++ b/core/src/cpp/include/host/vector/vec3.hpp
@@ -16,7 +16,6 @@
 
 #include <cmath>
 #include <machine/register.hpp>
-//#include <host/standard_test_host.hpp>
 #include "offsets.hpp"
 
 /**

--- a/core/src/cpp/include/loader/binary.hpp
+++ b/core/src/cpp/include/loader/binary.hpp
@@ -15,9 +15,9 @@
  */
 
 #include <cstdio>
+#include <host/definition.hpp>
 #include "error.hpp"
 #include "symbol.hpp"
-#include "host/definition.hpp"
 
 namespace MC64K::Loader {
 

--- a/core/src/cpp/include/loader/executable.hpp
+++ b/core/src/cpp/include/loader/executable.hpp
@@ -15,8 +15,8 @@
  */
 
 #include <cstdio>
-#include "misc/scalar.hpp"
-#include "machine/limits.hpp"
+#include <misc/scalar.hpp>
+#include <machine/limits.hpp>
 #include "dependency.hpp"
 #include "binary.hpp"
 

--- a/core/src/cpp/include/loader/symbol.hpp
+++ b/core/src/cpp/include/loader/symbol.hpp
@@ -15,9 +15,8 @@
  */
 
 #include <cstdio>
-#include "misc/exception.hpp"
-
 #include <initializer_list>
+#include <misc/exception.hpp>
 
 namespace MC64K::Loader {
 

--- a/core/src/cpp/include/machine/gnarly.hpp
+++ b/core/src/cpp/include/machine/gnarly.hpp
@@ -15,7 +15,7 @@
  */
 
 /**
- * Collection of gnarly macros. Bite me.
+ * Collection of horrible, gnarly macros. Bite me.
  */
 
 /**
@@ -34,8 +34,7 @@
  */
 #ifdef ALLOW_MISALIGNED_IMMEDIATE
 #define readDisplacement() \
-    iDisplacement = *((int32*)puProgramCounter); puProgramCounter+=4;
-
+    iDisplacement = *((int32*)puProgramCounter); puProgramCounter += 4;
 #else
 #define readDisplacement() \
     auBytes[0] = *puProgramCounter++; \
@@ -143,4 +142,29 @@
     puProgramCounter = (uint8 const*)(*(aoGPR[GPRegister::SP].puQuad)); \
     aoGPR[GPRegister::SP].puByte += 8;
 
+#ifdef REPORT_MIPS
+    #define initMIPSReport() \
+        std::fprintf(stderr, "Beginning run at PC:%p...\n", puProgramCounter); \
+        uint64 uInstructionCount = 0; \
+        Nanoseconds::Value uStart = Nanoseconds::mark();
+
+    #define updateMIPS() ++uInstructionCount;
+
+    #define outputMIPSReport() \
+        Nanoseconds::Value uElapsed = Nanoseconds::mark() - uStart; \
+        float64 fMIPS = (1000.0 * (float64)uInstructionCount) / (float64)uElapsed; \
+        std::fprintf( \
+            stderr, \
+            "Total instructions %lu in %lu nanoseconds, %.2f MIPS\n", \
+            uInstructionCount, \
+            uElapsed, \
+            fMIPS \
+        );
+#else
+    #define initMIPSReport()
+    #define updateMIPS()
+    #define outputMIPSReport()
 #endif
+
+#endif
+

--- a/core/src/cpp/include/machine/inline.hpp
+++ b/core/src/cpp/include/machine/inline.hpp
@@ -1,0 +1,88 @@
+#ifndef __MC64K_MACHINE_INLINE_HPP__
+#   define __MC64K_MACHINE_INLINE_HPP__
+
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+#include <cmath>
+#include "register.hpp"
+
+namespace MC64K::Machine {
+
+inline void rolByte(uint8* puValue, uint8 uSize) {
+    uSize &= 7;
+    uint8 val = *puValue;
+    *puValue = (uint8)(val << uSize | val >> (8 - uSize));
+}
+
+inline void rolWord(uint16* puValue, uint8 uSize) {
+    uSize &= 15;
+    uint16 val = *puValue;
+    *puValue = (uint16)(val << uSize | val >> (16 - uSize));
+}
+
+inline void rolLong(uint32* puValue, uint8 uSize) {
+    uSize &= 31;
+    uint32 val = *puValue;
+    *puValue = (uint32)(val << uSize | val >> (32 - uSize));
+}
+
+inline void rolQuad(uint64* puValue, uint8 uSize) {
+    uSize &= 63;
+    uint64 val = *puValue;
+    *puValue = (uint64)(val << uSize | val >> (64 - uSize));
+}
+
+inline void rorByte(uint8* puValue, uint8 uSize) {
+    uSize &= 7;
+    uint8 val = *puValue;
+    *puValue = (uint8)(val >> uSize | val << (8 - uSize));
+}
+
+inline void rorWord(uint16* puValue, uint8 uSize) {
+    uSize &= 15;
+    uint16 val = *puValue;
+    *puValue = (uint16)(val >> uSize | val << (16 - uSize));
+}
+
+inline void rorLong(uint32* puValue, uint8 uSize) {
+    uSize &= 31;
+    uint32 val = *puValue;
+    *puValue = (uint32)(val >> uSize | val << (32 - uSize));
+}
+
+inline void rorQuad(uint64* puValue, uint8 uSize) {
+    uSize &= 63;
+    uint64 val = *puValue;
+    *puValue = (uint64)(val >> uSize | val << (64 - uSize));
+}
+
+inline uint8 mapFloatClassification(int iClass) {
+    switch (iClass) {
+        case FP_ZERO:
+            return 0;
+        case FP_NORMAL:
+            return 1;
+        case FP_SUBNORMAL:
+            return 2;
+        case FP_INFINITE:
+            return 3;
+        case FP_NAN:
+        default:
+            return 4;
+    }
+}
+
+} // namespace
+#endif
+

--- a/core/src/cpp/include/machine/interpreter.hpp
+++ b/core/src/cpp/include/machine/interpreter.hpp
@@ -18,17 +18,12 @@
 #include "register.hpp"
 #include "error.hpp"
 
-namespace MC64K {
-
-/**
- * Forwards references
- */
-namespace Loader {
+namespace MC64K::Loader {
     class Executable;
     struct Symbol;
 }
 
-namespace Machine {
+namespace MC64K::Machine {
 
 /**
  * Interpreter
@@ -41,7 +36,7 @@ class Interpreter {
         /**
          * Status
          */
-        typedef enum {
+        enum Status {
             UNINITIALISED = 0,
             INITIALISED,
             RUNNING,
@@ -51,7 +46,7 @@ class Interpreter {
             UNIMPLEMENTED_EAMODE,
             UNKNOWN_HOST_CALL,
             INVALID_ENTRYPOINT
-        } Status;
+        };
 
         /**
          * Debug dump options
@@ -107,22 +102,6 @@ class Interpreter {
          * Run!
          */
         static void run();
-
-        /**
-         * Get a GRP register (range checked)
-         *
-         * @param  unsigned int const uReg
-         * @return GPRegister&
-         */
-        static GPRegister& gpr(unsigned int const uReg);
-
-        /**
-         * Get a FPR register (range checked)
-         *
-         * @param  unsigned int const uReg
-         * @return FPRegister&
-         */
-        static FPRegister& fpr(unsigned int const uReg);
 
         /**
          * Get the GP register set (array access)
@@ -243,20 +222,6 @@ inline FPRegister* Interpreter::fpr() {
 /**
  * @inheritDoc
  */
-inline GPRegister& Interpreter::gpr(unsigned int const uReg) {
-    return aoGPR[uReg & GPRegister::MASK];
-}
-
-/**
- * @inheritDoc
- */
-inline FPRegister& Interpreter::fpr(unsigned int const uReg) {
-    return aoFPR[uReg & FPRegister::MASK];
-}
-
-/**
- * @inheritDoc
- */
 template<unsigned N>
 inline constexpr GPRegister& Interpreter::gpr() {
     static_assert(N < GPRegister::MAX, "Invalid GPR number");
@@ -272,6 +237,5 @@ inline constexpr FPRegister& Interpreter::fpr() {
     return aoFPR[N];
 }
 
-
-}} // namespace
+} // namespace
 #endif

--- a/core/src/cpp/include/machine/interpreter.hpp
+++ b/core/src/cpp/include/machine/interpreter.hpp
@@ -155,7 +155,7 @@ class Interpreter {
         static uint8*           puStackBase;
         static HCFVector const* pcHCFVectors;
         static Loader::Symbol*  poImportSymbols;
-        static int32            iCallDepth;
+        //static int32            iCallDepth;
         static uint32           uNumHCFVectors;
         static uint32           uNumImportSymbols;
 
@@ -196,6 +196,8 @@ class Interpreter {
          * @param uint8  const uEAMode
          */
         static void  restoreRegisters(uint32 const uMask, uint8 const uEAMode);
+
+        static void  handleHCF();
 };
 
 /**

--- a/core/src/cpp/include/machine/register.hpp
+++ b/core/src/cpp/include/machine/register.hpp
@@ -14,8 +14,8 @@
  *    - 64-bit 680x0-inspired Virtual Machine and assembler -
  */
 
-#include "misc/scalar.hpp"
 #include <type_traits>
+#include <misc/scalar.hpp>
 
 namespace MC64K::Machine {
 

--- a/core/src/cpp/include/machine/timing.hpp
+++ b/core/src/cpp/include/machine/timing.hpp
@@ -14,8 +14,8 @@
  *    - 64-bit 680x0-inspired Virtual Machine and assembler -
  */
 
-#include "mc64k.hpp"
 #include <time.h>
+#include <mc64k.hpp>
 
 namespace MC64K::Machine {
 

--- a/core/src/cpp/loader/binary.cpp
+++ b/core/src/cpp/loader/binary.cpp
@@ -14,9 +14,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <new>
-#include "mc64k.hpp"
-#include "loader/executable.hpp"
-#include "host/definition.hpp"
+#include <mc64k.hpp>
+#include <loader/executable.hpp>
+#include <host/definition.hpp>
 
 namespace MC64K::Loader {
 

--- a/core/src/cpp/loader/executable.cpp
+++ b/core/src/cpp/loader/executable.cpp
@@ -14,9 +14,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <new>
-#include "mc64k.hpp"
-#include "loader/executable.hpp"
-#include "host/definition.hpp"
+#include <mc64k.hpp>
+#include <loader/executable.hpp>
+#include <host/definition.hpp>
 
 namespace MC64K::Loader {
 

--- a/core/src/cpp/loader/symbol.cpp
+++ b/core/src/cpp/loader/symbol.cpp
@@ -14,9 +14,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <new>
-#include "mc64k.hpp"
-#include "loader/executable.hpp"
-#include "host/definition.hpp"
+#include <mc64k.hpp>
+#include <loader/executable.hpp>
+#include <host/definition.hpp>
 
 namespace MC64K::Loader {
 

--- a/core/src/cpp/machine/interpreter.cpp
+++ b/core/src/cpp/machine/interpreter.cpp
@@ -15,10 +15,10 @@
 #include <cstring>
 #include <cstdlib>
 #include <cassert>
-#include "machine/error.hpp"
-#include "machine/limits.hpp"
-#include "machine/interpreter.hpp"
-#include "loader/executable.hpp"
+#include <machine/error.hpp>
+#include <machine/limits.hpp>
+#include <machine/interpreter.hpp>
+#include <loader/executable.hpp>
 
 namespace MC64K::Machine {
 
@@ -40,7 +40,7 @@ void*           Interpreter::pTmpEA                 = 0;
 uint8*          Interpreter::puStackTop             = 0;
 uint8*          Interpreter::puStackBase            = 0;
 Loader::Symbol* Interpreter::poImportSymbols        = 0;
-int32           Interpreter::iCallDepth             = 0;
+//int32           Interpreter::iCallDepth             = 0;
 uint32          Interpreter::uNumHCFVectors         = 0;
 uint32          Interpreter::uNumImportSymbols      = 0;
 
@@ -126,13 +126,13 @@ void Interpreter::dumpState(std::FILE* poStream, unsigned const uFlags) {
             poStream,
             "Machine State\n"
             "\tProgram Counter: %p [... 0x%02X > 0x%02X < 0x%02X ...]\n"
-            "\tCall Depth:      %d\n"
+            //"\tCall Depth:      %d\n"
             "\tStatus:          %d [%s]\n\n",
             puProgramCounter,
             (uint32) *(puProgramCounter - 1),
             (uint32) *(puProgramCounter),
             (uint32) *(puProgramCounter + 1),
-            iCallDepth,
+            //iCallDepth,
             eStatus,
             asStatusNames[eStatus]
         );
@@ -140,9 +140,9 @@ void Interpreter::dumpState(std::FILE* poStream, unsigned const uFlags) {
         std::fprintf(
             poStream,
             "Machine State\n"
-            "\tCall Depth:      %d\n"
+            //"\tCall Depth:      %d\n"
             "\tStatus:          %d [%s]\n\n",
-            iCallDepth,
+            //iCallDepth,
             eStatus,
             asStatusNames[eStatus]
         );
@@ -241,7 +241,6 @@ void Interpreter::dumpState(std::FILE* poStream, unsigned const uFlags) {
         }
         std::fprintf(poStream, "\n");
     }
-
 }
 
 } // namespace

--- a/core/src/cpp/mc64k.make
+++ b/core/src/cpp/mc64k.make
@@ -1,6 +1,6 @@
 # Common include for building the interpreter
 
-OBJ = obj/$(ARCH)/machine/interpreter.o obj/$(ARCH)/host/standard_test_host_mem.o obj/$(ARCH)/host/standard_test_host_io.o obj/$(ARCH)/host/standard_test_host_vector_math.o obj/$(ARCH)/main.o obj/$(ARCH)/host/definition.o obj/$(ARCH)/host/standard_test_host_def.o obj/$(ARCH)/host/runtime.o obj/$(ARCH)/loader/symbol.o obj/$(ARCH)/loader/binary.o obj/$(ARCH)/loader/executable.o obj/$(ARCH)/misc/version.o
+OBJ = obj/$(ARCH)/machine/interpreter.o obj/$(ARCH)/host/standard_test_host_mem.o obj/$(ARCH)/host/standard_test_host_io.o obj/$(ARCH)/host/standard_test_host_vector_math.o obj/$(ARCH)/host/standard_test_host_display.o obj/$(ARCH)/main.o obj/$(ARCH)/host/definition.o obj/$(ARCH)/host/standard_test_host_def.o obj/$(ARCH)/host/runtime.o obj/$(ARCH)/loader/symbol.o obj/$(ARCH)/loader/binary.o obj/$(ARCH)/loader/executable.o obj/$(ARCH)/misc/version.o
 
 $(BIN): $(OBJ) Makefile.$(MEXT)
 	$(CXX) $(CXXFLAGS) $(OBJ) -o $(BIN)

--- a/core/src/cpp/misc/version.cpp
+++ b/core/src/cpp/misc/version.cpp
@@ -11,9 +11,7 @@
  *    - 64-bit 680x0-inspired Virtual Machine and assembler -
  */
 
-#include <cstdio>
-#include <cstdlib>
-#include "misc/version.hpp"
+#include <misc/version.hpp>
 
 namespace MC64K::Misc {
 

--- a/docs/programming/tutorial/p_02.md
+++ b/docs/programming/tutorial/p_02.md
@@ -38,14 +38,10 @@ To break down what is going on:
     - We define the string using the dc.b (declare constant bytes) pseudo operation.
     - This normally expects a comma separated list of integer values but accepts character strings as a shorthand notation.
     - Note that the string literal includes a terminating null character. This isn't C. Forgetting it will end in disaster.
-* We push a byte containing the value 2 onto the stack:
-    - This byte designates a specific host native operation we want to perform.
-* We invoke HCF Vector 0:
+* We invoke operation 2 of HCF Vector 0:
     - This designates the host vector for IO operations.
     - The code exits the interpreter here and invokes the specific operation.
     - For HCF Vector 0, operation 2 prints a string pointed to by a0 to the standard output stream of the host.
-* We restore the stack.
-    - This is important, even though we are about to exit the code.
 * Output happens. Magic.
 
 ### Improving readability


### PR DESCRIPTION
- Ongoing modernisation fixes and tidying
- Started a new Host Vector for Display
    - Implements the scaffolding for a host native refresh/input-capture event loop that calls back to a VM supplied callback
    - Requires some interesting workarounds when compiling with -DUSE_GLOBAL_REGISTER due to clobbering issues.
    - Fixes for reentrance in the main Interpreter run() behaviour mean that several previously global properties (current VM call depth etc) are now local and not visible.
    - Made overall MIPS report from run() a compile time option as it is particularly noisy for callback testing.
    - HCF handling more complicated as any HCF that ran a callback needs to return status INITIALISED for the calling context to know it needs to adjust the program counter.
    - Moved some of the handling out of the hot path as the impact on performance was substantial even when the code is not called (instruction cache effect)