### PR TITLE
Implemented FINFO operations

### DIFF
--- a/assembler/libs/standard_test_host/v1.0.0/finfo.s
+++ b/assembler/libs/standard_test_host/v1.0.0/finfo.s
@@ -1,0 +1,21 @@
+
+;  888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+;  8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+;  88888b.d88888 888    888 888          d8P 888  888  d8P
+;  888Y88888P888 888        888d888b.   d8P  888  888d88K
+;  888 Y888P 888 888        888P "Y88b d88   888  8888888b
+;  888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+;  888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+;  888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+;
+;   - 64-bit 680x0-inspired Virtual Machine and assembler -
+;
+; Constants relating to the result of finfo.s/d
+
+    @equ FINFO_BIT_NONZERO   0  ; Set for any valid float that is nonzero
+    @equ FINFO_BIT_NEGATIVE  1  ; Set for any valid float that is negative
+    @equ FINFO_BIT_SUBNORMAL 2  ; Set for any float that has a subnormal representation
+    @equ FINFO_BIT_INFINITE  3  ; Set for any float approaching +/- infinity
+    @equ FINFO_BIT_NAN       4  ; Set for any value that is not a valid float
+    @equ FINFO_BIT_UNKNOWN   5  ; Set if the value could not be classified
+

--- a/assembler/src/defs/mnemonic/IMatches.php
+++ b/assembler/src/defs/mnemonic/IMatches.php
@@ -322,20 +322,6 @@ interface IMatches {
         'flog2.d'   => IArithmetic::FLOG2_D,
         'ftwotox.s' => IArithmetic::FTWOTOX_S,
         'ftwotox.d' => IArithmetic::FTWOTOX_D,
-/*
-        'reserved0',
-        'reserved1',
-        'reserved2',
-        'reserved3',
-        'reserved4',
-        'reserved5',
-        'reserved6',
-        'reserved7',
-        'reserved8',
-        'reserved9',
-        'reserved10',
-        'reserved11',
-*/
     ];
 
     // Subopcode matches (2 bytes)

--- a/assembler/test_projects/tricky/src/main.s
+++ b/assembler/test_projects/tricky/src/main.s
@@ -25,7 +25,7 @@ main:
     ;fmove.s .float1, .float3
     ;fadd.s  .float2, .float3
     fbgt.s  .float3, .float1, .nerr
-
+    finfo.s .float1, d0
     rts
 
 

--- a/core/src/cpp/include/machine/inline.hpp
+++ b/core/src/cpp/include/machine/inline.hpp
@@ -67,21 +67,37 @@ inline void rorQuad(uint64* puValue, uint8 uSize) {
     *puValue = (uint64)(val >> uSize | val << (64 - uSize));
 }
 
-inline uint8 mapFloatClassification(int iClass) {
+template<typename T>
+inline uint8 classifyFloat(T const & fValue) {
+    static_assert(
+        std::is_floating_point<T>::value,
+        "Invalid template type, must be float or double"
+    );
+
+    uint8 uResult = Limits::F_ZERO;
+    int iClass = std::fpclassify(fValue);
     switch (iClass) {
         case FP_ZERO:
-            return 0;
-        case FP_NORMAL:
-            return 1;
-        case FP_SUBNORMAL:
-            return 2;
-        case FP_INFINITE:
-            return 3;
+            return uResult;
         case FP_NAN:
+            return Limits::F_NAN;
+        case FP_SUBNORMAL:
+            uResult |= Limits::F_SUBNORMAL;
+            break;
+        case FP_INFINITE:
+            uResult |= Limits::F_INFINITE;
+            break;
+        case FP_NORMAL:
+            break;
         default:
-            return 4;
+            return Limits::F_UNKNOWN;
     }
+
+    uResult |= Limits::F_NONZERO;
+    uResult |= (uint8)((fValue < 0.0) ? Limits::F_NEGATIVE : 0);
+    return uResult;
 }
+
 
 } // namespace
 #endif

--- a/core/src/cpp/include/machine/limits.hpp
+++ b/core/src/cpp/include/machine/limits.hpp
@@ -27,5 +27,15 @@ enum {
     MAX_STACK_SIZE  = 1 << 23
 };
 
+enum {
+    F_ZERO      =  0,
+    F_NONZERO   =  1,
+    F_NEGATIVE  =  2,
+    F_SUBNORMAL =  4,
+    F_INFINITE  =  8,
+    F_NAN       = 16,
+    F_UNKNOWN   = 32
+};
+
 } // namespace
 #endif

--- a/core/src/cpp/machine/interpreter_run.cpp
+++ b/core/src/cpp/machine/interpreter_run.cpp
@@ -586,13 +586,13 @@ void Interpreter::run() {
 
             case Opcode::FINFO_S: {
                 dyadic2(SIZE_BYTE, SIZE_LONG);
-                asUByte(pDstEA) = mapFloatClassification(std::fpclassify(asSingle(pSrcEA)));
+                asUByte(pDstEA) = classifyFloat(asSingle(pSrcEA));
                 break;
             }
 
             case Opcode::FINFO_D: {
                 dyadic2(SIZE_BYTE, SIZE_QUAD);
-                asUByte(pDstEA) = mapFloatClassification(std::fpclassify(asDouble(pSrcEA)));
+                asUByte(pDstEA) = classifyFloat(asDouble(pSrcEA));
                 break;
             }
 


### PR DESCRIPTION
Properly defined the behaviour of finfo.s and finfo.d operations. These now set a byte bitmask value comprised of the following bits

- Bit 0 - Set when the source operand is valid and nonzero
- Bit 1 - Set when the source operand is valid and negative
- Bit 2 - Set when the source operand has a subnormal representation
- Bit 3 - Set when the source operand has infinite magnitude (see bit 1 for sign)
- Bit 4 - Set when the source operand is Not A Number
- Bit 5 - Set when the source operand could not be classified.