### PR TITLE
Sign flip bug for float immediates

### DIFF
--- a/assembler/src/parser/utils/ConstIntExpression.php
+++ b/assembler/src/parser/utils/ConstIntExpression.php
@@ -120,10 +120,11 @@ class ConstIntExpression implements IParser {
     }
 
     /**
-     * Checks that the string contains both digits and operators, or there is little point in doing the effort.
+     * Checks that the string contains both digits and operators, or there is little point in doing the effort. Also excludes the red-herring caused by negative value declarations
      */
     private function hasRequired(string $sPossibleExpression): bool {
-        return preg_match('/\d/', $sPossibleExpression) &&
+        return false === preg_match('/^-\s*\d+$/', $sPossibleExpression) &&
+               preg_match('/\d/', $sPossibleExpression) &&
                preg_match('/[\+\-\*\\/\%\<\>\&\|\~\^]/', $sPossibleExpression);
     }
 

--- a/assembler/test_projects/bug_of_the_week/bin/README.md
+++ b/assembler/test_projects/bug_of_the_week/bin/README.md
@@ -1,0 +1,1 @@
+Build Location for bug of the week

--- a/assembler/test_projects/bug_of_the_week/proj.json
+++ b/assembler/test_projects/bug_of_the_week/proj.json
@@ -1,0 +1,26 @@
+{
+    "target": {
+        "name": "BugOfTheWeek",
+        "version": "1.0.0",
+        "description": "General Bug Evaluation",
+        "output": "bin/botw.64x",
+        "host": {
+            "name": "Standard Test Host",
+            "version": "1.0.0"
+        }
+    },
+    "options": {
+        "log_code_folds": true,
+        "log_label_add": true,
+        "log_label_ref": true,
+        "log_label_resolve": true
+    },
+    "sources": [
+        "lib:standard_test_host/v1.0.0/host.s",
+        "lib:standard_test_host/v1.0.0/mem.s",
+        "lib:standard_test_host/v1.0.0/io.s",
+        "src/main.s"
+    ],
+    "defines": {
+    }
+}

--- a/assembler/test_projects/bug_of_the_week/src/main.s
+++ b/assembler/test_projects/bug_of_the_week/src/main.s
@@ -1,0 +1,32 @@
+
+;  888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+;  8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+;  88888b.d88888 888    888 888          d8P 888  888  d8P
+;  888Y88888P888 888        888d888b.   d8P  888  888d88K
+;  888 Y888P 888 888        888P "Y88b d88   888  8888888b
+;  888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+;  888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+;  888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+;
+;   - 64-bit 680x0-inspired Virtual Machine and assembler -
+;
+; Bug Of The Week project - main.s
+
+    @def nanotime dc.b 0xF0 ; super undocumented opcodes ftw
+
+    @equ FP_ZERO 0.0
+    @equ FP_MINUS_HALF -0.5
+    @equ FP_MINUS_ONE -1.0
+
+main:
+    hcf io_init
+
+    fmove.s #FP_ZERO, fp0
+    fmove.s #FP_MINUS_HALF, fp1
+    fmove.s #FP_MINUS_ONE, fp2
+    fmove.s #-0.25, fp3
+
+
+exit:
+    hcf io_done
+    rts


### PR DESCRIPTION
Fixed bug that flipped the sign of floating point literals in the range -1 < x < 0.

- This was caused by the ConstIntExpression parser matching the sign and digits before the decimal point as a possible expression for evaluation. This was then interpreted as -0, which was replaced with 0.