### PR TITLE
Implemented 8-bit fixed displacement EA modes

### DIFF
--- a/assembler/src/classmap.php
+++ b/assembler/src/classmap.php
@@ -75,6 +75,7 @@ const CLASS_MAP = [
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\FPRDirect' => '/parser/effective_address/FPRDirect.php',
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\IParser' => '/parser/effective_address/IParser.php',
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\ARDirect' => '/parser/effective_address/ARDirect.php',
+  'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\TDisplacementSizeAware' => '/parser/effective_address/TDisplacementSizeAware.php',
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\TOperationSizeAware' => '/parser/effective_address/TOperationSizeAware.php',
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\TPotentiallyFoldableImmediateAware' => '/parser/effective_address/TPotentiallyFoldableImmediateAware.php',
   'ABadCafe\\MC64K\\Parser\\EffectiveAddress\\AllControlAddressing' => '/parser/effective_address/AllControlAddressing.php',

--- a/assembler/src/defs/effective_address/IByteCodeGroups.php
+++ b/assembler/src/defs/effective_address/IByteCodeGroups.php
@@ -28,20 +28,22 @@ namespace ABadCafe\MC64K\Defs\EffectiveAddress;
  */
 interface IByteCodeGroups {
     const
-        OFS_GPR_DIR          = 0,   // GPR Direct r<N>
-        OFS_GPR_IND          = self::OFS_GPR_DIR + 16,           // GPR Indirect (r<N>)
-        OFS_GPR_IND_POST_INC = self::OFS_GPR_IND + 16,           // GPR Indirect, Post Increment (r<N>)+
-        OFS_GPR_IND_POST_DEC = self::OFS_GPR_IND_POST_INC + 16,  // GPR Indirect, Post Decrement (r<N>)-
-        OFS_GPR_IND_PRE_INC  = self::OFS_GPR_IND_POST_DEC + 16,  // GPR Indirect, Pre Increment +(r<N>)
-        OFS_GPR_IND_PRE_DEC  = self::OFS_GPR_IND_PRE_INC  + 16,  // GPR Indirect, Pre Decrement -(r<N>)
-        OFS_GPR_IND_DSP      = self::OFS_GPR_IND_PRE_DEC  + 16,  // GPR Indirect with Displacement <d32>(r<N>) / (<d32>, r<N>)
-        OFS_FPR_DIR          = self::OFS_GPR_IND_DSP + 16,       // FPR Direct fp<N>
-        OFS_GPR_IDX          = self::OFS_FPR_DIR + 16,           // GPR Indexed (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-        OFS_GPR_IDX_DSP      = self::OFS_GPR_IDX + 16,           // GPR Indexed with Displacement <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-        OFS_OTHER            = self::OFS_GPR_IDX_DSP + 16,       // Sundry modes (space for 32 of them)
+        OFS_GPR_DIR          = 0,                                // r<N>
+        OFS_GPR_IND          = self::OFS_GPR_DIR          + 16,  // (r<N>)
+        OFS_GPR_IND_POST_INC = self::OFS_GPR_IND          + 16,  // (r<N>)+
+        OFS_GPR_IND_POST_DEC = self::OFS_GPR_IND_POST_INC + 16,  // (r<N>)-
+        OFS_GPR_IND_PRE_INC  = self::OFS_GPR_IND_POST_DEC + 16,  // +(r<N>)
+        OFS_GPR_IND_PRE_DEC  = self::OFS_GPR_IND_PRE_INC  + 16,  // -(r<N>)
+        OFS_GPR_IND_DSP8     = self::OFS_GPR_IND_PRE_DEC  + 16,  // <d8>(r<N>)
+        OFS_GPR_IND_DSP      = self::OFS_GPR_IND_DSP8     + 16,  // <d32>(r<N>)
+        OFS_FPR_DIR          = self::OFS_GPR_IND_DSP      + 16,  // fp<N>
+        OFS_GPR_IDX          = self::OFS_FPR_DIR          + 16,  // (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_GPR_IDX_DSP8     = self::OFS_GPR_IDX          + 16,  // <d8>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_GPR_IDX_DSP      = self::OFS_GPR_IDX_DSP8     + 16,  // <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_OTHER            = self::OFS_GPR_IDX_DSP      + 16,  // Sundry modes (space for 32 of them)
 
         // Re-enumerated these but we aren't supporting them for the time being.
-        OFS_PC_IND_IDX       = self::OFS_OTHER + 16,             // PC Indirect, indexed  (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
-        OFS_PC_IND_IDX_DSP   = self::OFS_PC_IND_IDX + 16         // PC Indirect, indeced with displacement  <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_PC_IND_IDX       = self::OFS_OTHER            + 16,  // (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_PC_IND_IDX_DSP   = self::OFS_PC_IND_IDX       + 16   // <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
     ;
 }

--- a/assembler/src/defs/effective_address/IByteCodeGroups.php
+++ b/assembler/src/defs/effective_address/IByteCodeGroups.php
@@ -29,19 +29,19 @@ namespace ABadCafe\MC64K\Defs\EffectiveAddress;
 interface IByteCodeGroups {
     const
         OFS_GPR_DIR          = 0,   // GPR Direct r<N>
-        OFS_GPR_IND          = 16,  // GPR Indirect (r<N>)
-        OFS_GPR_IND_POST_INC = 32,  // GPR Indirect, Post Increment (r<N>)+
-        OFS_GPR_IND_POST_DEC = 48,  // GPR Indirect, Post Decrement (r<N>)-
-        OFS_GPR_IND_PRE_INC  = 64,  // GPR Indirect, Pre Increment +(r<N>)
-        OFS_GPR_IND_PRE_DEC  = 80,  // GPR Indirect, Pre Decrement -(r<N>)
-        OFS_GPR_IND_DSP      = 96,  // GPR Indirect with Displacement <d32>(r<N>) / (<d32>, r<N>)
-        OFS_FPR_DIR          = 112, // FPR Direct fp<N>
-        OFS_GPR_IDX          = 128, // GPR Indexed (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-        OFS_GPR_IDX_DSP      = 144, // GPR Indexed with Displacement <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-        OFS_OTHER            = 160, // Sundry modes (space for 32 of them)
+        OFS_GPR_IND          = self::OFS_GPR_DIR + 16,           // GPR Indirect (r<N>)
+        OFS_GPR_IND_POST_INC = self::OFS_GPR_IND + 16,           // GPR Indirect, Post Increment (r<N>)+
+        OFS_GPR_IND_POST_DEC = self::OFS_GPR_IND_POST_INC + 16,  // GPR Indirect, Post Decrement (r<N>)-
+        OFS_GPR_IND_PRE_INC  = self::OFS_GPR_IND_POST_DEC + 16,  // GPR Indirect, Pre Increment +(r<N>)
+        OFS_GPR_IND_PRE_DEC  = self::OFS_GPR_IND_PRE_INC  + 16,  // GPR Indirect, Pre Decrement -(r<N>)
+        OFS_GPR_IND_DSP      = self::OFS_GPR_IND_PRE_DEC  + 16,  // GPR Indirect with Displacement <d32>(r<N>) / (<d32>, r<N>)
+        OFS_FPR_DIR          = self::OFS_GPR_IND_DSP + 16,       // FPR Direct fp<N>
+        OFS_GPR_IDX          = self::OFS_FPR_DIR + 16,           // GPR Indexed (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_GPR_IDX_DSP      = self::OFS_GPR_IDX + 16,           // GPR Indexed with Displacement <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_OTHER            = self::OFS_GPR_IDX_DSP + 16,       // Sundry modes (space for 32 of them)
 
         // Re-enumerated these but we aren't supporting them for the time being.
-        OFS_PC_IND_IDX       = 192, // PC Indirect, indexed  (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
-        OFS_PC_IND_IDX_DSP   = 208  // PC Indirect, indeced with displacement  <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_PC_IND_IDX       = self::OFS_OTHER + 16,             // PC Indirect, indexed  (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
+        OFS_PC_IND_IDX_DSP   = self::OFS_PC_IND_IDX + 16         // PC Indirect, indeced with displacement  <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
     ;
 }

--- a/assembler/src/defs/effective_address/IRegisterIndirect.php
+++ b/assembler/src/defs/effective_address/IRegisterIndirect.php
@@ -115,6 +115,24 @@ interface IRegisterIndirect extends IByteCodeGroups {
         R14_IND_PRE_DEC   = self::OFS_GPR_IND_PRE_DEC + 14,
         R15_IND_PRE_DEC   = self::OFS_GPR_IND_PRE_DEC + 15,
 
+        // Register Indirect with displacement <d8>(r<N>) / (<d8>, r<N>)
+        R0_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 0,
+        R1_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 1,
+        R2_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 2,
+        R3_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 3,
+        R4_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 4,
+        R5_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 5,
+        R6_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 6,
+        R7_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 7,
+        R8_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 8,
+        R9_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 9,
+        R10_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 10,
+        R11_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 11,
+        R12_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 12,
+        R13_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 13,
+        R14_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 14,
+        R15_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 15,
+
         // Register Indirect with displacement <d32>(r<N>) / (<d32>, r<N>)
         R0_IND_DSP    = self::OFS_GPR_IND_DSP + 0,
         R1_IND_DSP    = self::OFS_GPR_IND_DSP + 1,

--- a/assembler/src/defs/effective_address/IRegisterIndirect.php
+++ b/assembler/src/defs/effective_address/IRegisterIndirect.php
@@ -115,7 +115,7 @@ interface IRegisterIndirect extends IByteCodeGroups {
         R14_IND_PRE_DEC   = self::OFS_GPR_IND_PRE_DEC + 14,
         R15_IND_PRE_DEC   = self::OFS_GPR_IND_PRE_DEC + 15,
 
-        // Register Indirect with displacement <d8>(r<N>) / (<d8>, r<N>)
+        // Register Indirect with 8-bit displacement <d8>(r<N>) / (<d8>, r<N>)
         R0_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 0,
         R1_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 1,
         R2_IND_DSP8    = self::OFS_GPR_IND_DSP8 + 2,
@@ -133,7 +133,7 @@ interface IRegisterIndirect extends IByteCodeGroups {
         R14_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 14,
         R15_IND_DSP8   = self::OFS_GPR_IND_DSP8 + 15,
 
-        // Register Indirect with displacement <d32>(r<N>) / (<d32>, r<N>)
+        // Register Indirect with 32-bit displacement <d32>(r<N>) / (<d32>, r<N>)
         R0_IND_DSP    = self::OFS_GPR_IND_DSP + 0,
         R1_IND_DSP    = self::OFS_GPR_IND_DSP + 1,
         R2_IND_DSP    = self::OFS_GPR_IND_DSP + 2,

--- a/assembler/src/defs/effective_address/IRegisterIndirectIndexed.php
+++ b/assembler/src/defs/effective_address/IRegisterIndirectIndexed.php
@@ -49,25 +49,51 @@ interface IRegisterIndirectIndexed extends IByteCodeGroups {
         REG_IND_IDXL_8     = self::OFS_GPR_IDX + 14, // (r7, r0.l*8)
         REG_IND_IDXQ_8     = self::OFS_GPR_IDX + 15, // (r7, r0.q*8)
 
-        // Register Indirect with 8-bit scaled index and displacement
+
+        // Register Indirect with 8-bit scaled index and 8-bit displacement
+        REG_IND_IDXB_DSP8   = self::OFS_GPR_IDX_DSP8 +  0, // -2(r7, r0.b)    OR (-2, r7, r0.b)
+        REG_IND_IDXW_DSP8   = self::OFS_GPR_IDX_DSP8 +  1, // -2(r7, r0.w)    OR (-2, r7, r0.w)
+        REG_IND_IDXL_DSP8   = self::OFS_GPR_IDX_DSP8 +  2, // -2(r7, r0.l)    OR (-2, r7, r0.l)
+        REG_IND_IDXQ_DSP8   = self::OFS_GPR_IDX_DSP8 +  3, // -2(r7, r0.q)    OR (-2, r7, r0.q)
+
+        // Register Indirect with 16-bit scaled index and 8-bit displacement
+        REG_IND_IDXB_2_DSP8 = self::OFS_GPR_IDX_DSP8 +  4, // 8(r7, r0.b*2)   OR (8, r7, r0.b*2)
+        REG_IND_IDXW_2_DSP8 = self::OFS_GPR_IDX_DSP8 +  5, // 8(r7, r0.w*2)   OR (8, r7, r0.w*2)
+        REG_IND_IDXL_2_DSP8 = self::OFS_GPR_IDX_DSP8 +  6, // 8(r7, r0.l*2)   OR (8, r7, r0.l*2)
+        REG_IND_IDXQ_2_DSP8 = self::OFS_GPR_IDX_DSP8 +  7, // 8(r7, r0.q*2)   OR (8, r7, r0.q*2)
+
+        // Register Indirect with 32-bit scaled index and 8-bit displacement
+        REG_IND_IDXB_4_DSP8 = self::OFS_GPR_IDX_DSP8 +  8, // -6(r7, r0.b*4)  OR (-2, r7, r0.b*4)
+        REG_IND_IDXW_4_DSP8 = self::OFS_GPR_IDX_DSP8 +  9, // -6(r7, r0.w*4)  OR (-2, r7, r0.w*4)
+        REG_IND_IDXL_4_DSP8 = self::OFS_GPR_IDX_DSP8 + 10, // -6(r7, r0.l*4)  OR (-2, r7, r0.l*4)
+        REG_IND_IDXQ_4_DSP8 = self::OFS_GPR_IDX_DSP8 + 11, // -6(r7, r0.q*4)  OR (-2, r7, r0.q*4)
+
+        // Register Indirect with 64-bit scaled index and 8-bit displacement
+        REG_IND_IDXB_8_DSP8 = self::OFS_GPR_IDX_DSP8 + 12, // 2(r7, r0.b*8)   OR (2, r7, r0.b*8)
+        REG_IND_IDXW_8_DSP8 = self::OFS_GPR_IDX_DSP8 + 13, // 2(r7, r0.w*8)   OR (2, r7, r0.w*8)
+        REG_IND_IDXL_8_DSP8 = self::OFS_GPR_IDX_DSP8 + 14, // 2(r7, r0.l*8)   OR (2, r7, r0.l*8)
+        REG_IND_IDXQ_8_DSP8 = self::OFS_GPR_IDX_DSP8 + 15, // 2(r7, r0.q*8)   OR (2, r7, r0.q*8)
+
+
+        // Register Indirect with 8-bit scaled index and 32-bit displacement
         REG_IND_IDXB_DSP   = self::OFS_GPR_IDX_DSP +  0, // -2(r7, r0.b)    OR (-2, r7, r0.b)
         REG_IND_IDXW_DSP   = self::OFS_GPR_IDX_DSP +  1, // -2(r7, r0.w)    OR (-2, r7, r0.w)
         REG_IND_IDXL_DSP   = self::OFS_GPR_IDX_DSP +  2, // -2(r7, r0.l)    OR (-2, r7, r0.l)
         REG_IND_IDXQ_DSP   = self::OFS_GPR_IDX_DSP +  3, // -2(r7, r0.q)    OR (-2, r7, r0.q)
 
-        // Register Indirect with 16-bit scaled index and displacement
+        // Register Indirect with 16-bit scaled index and 32-bit displacement
         REG_IND_IDXB_2_DSP = self::OFS_GPR_IDX_DSP +  4, // 8(r7, r0.b*2)   OR (8, r7, r0.b*2)
         REG_IND_IDXW_2_DSP = self::OFS_GPR_IDX_DSP +  5, // 8(r7, r0.w*2)   OR (8, r7, r0.w*2)
         REG_IND_IDXL_2_DSP = self::OFS_GPR_IDX_DSP +  6, // 8(r7, r0.l*2)   OR (8, r7, r0.l*2)
         REG_IND_IDXQ_2_DSP = self::OFS_GPR_IDX_DSP +  7, // 8(r7, r0.q*2)   OR (8, r7, r0.q*2)
 
-        // Register Indirect with 32-bit scaled index and displacement
+        // Register Indirect with 32-bit scaled index and 32-bit displacement
         REG_IND_IDXB_4_DSP = self::OFS_GPR_IDX_DSP +  8, // -6(r7, r0.b*4)  OR (-2, r7, r0.b*4)
         REG_IND_IDXW_4_DSP = self::OFS_GPR_IDX_DSP +  9, // -6(r7, r0.w*4)  OR (-2, r7, r0.w*4)
         REG_IND_IDXL_4_DSP = self::OFS_GPR_IDX_DSP + 10, // -6(r7, r0.l*4)  OR (-2, r7, r0.l*4)
         REG_IND_IDXQ_4_DSP = self::OFS_GPR_IDX_DSP + 11, // -6(r7, r0.q*4)  OR (-2, r7, r0.q*4)
 
-        // Register Indirect with 64-bit scaled index and displacement
+        // Register Indirect with 64-bit scaled index and 32-bit displacement
         REG_IND_IDXB_8_DSP = self::OFS_GPR_IDX_DSP + 12, // 2(r7, r0.b*8)   OR (2, r7, r0.b*8)
         REG_IND_IDXW_8_DSP = self::OFS_GPR_IDX_DSP + 13, // 2(r7, r0.w*8)   OR (2, r7, r0.w*8)
         REG_IND_IDXL_8_DSP = self::OFS_GPR_IDX_DSP + 14, // 2(r7, r0.l*8)   OR (2, r7, r0.l*8)

--- a/assembler/src/parser/effective_address/TDisplacementSizeAware.php
+++ b/assembler/src/parser/effective_address/TDisplacementSizeAware.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+declare(strict_types = 1);
+
+namespace ABadCafe\MC64K\Parser\EffectiveAddress;
+use ABadCafe\MC64K\Defs\IIntLimits;
+
+/**
+ * TDisplacementSizeAware
+ *
+ * Minmimal guts for Parser implementations that need to know an operation size, primarily immediate modes.
+ */
+trait TDisplacementSizeAware {
+
+    private function fitsByte(int $iDisplacement): bool {
+        return
+            $iDisplacement >= IIntLimits::BYTE_MIN_SIGNED &&
+            $iDisplacement <= IIntLimits::BYTE_MAX_SIGNED
+        ;
+    }
+}

--- a/assembler/src/parser/source_line/Processor.php
+++ b/assembler/src/parser/source_line/Processor.php
@@ -70,9 +70,14 @@ class Processor implements IParser {
         foreach ($this->aParsers as $oParser) {
             if ($oParser->checkLine($sSourceLine)) {
                 $sByteCode = $oParser->parse($sSourceLine);
-
-                //printf("\n\t%24s [%2d]: %s\n\n", bin2hex($sByteCode), strlen($sByteCode), $sSourceLine);
-
+                if ($oParser instanceof Instruction\Statement) {
+                    printf(
+                        "\t%24s [%2d]: %s\n",
+                        bin2hex($sByteCode),
+                        strlen($sByteCode),
+                        $sSourceLine
+                    );
+                }
                 return $sByteCode;
             }
         }

--- a/assembler/src/tests/DisplacedIndirectEATest.php
+++ b/assembler/src/tests/DisplacedIndirectEATest.php
@@ -29,39 +29,39 @@ use ABadCafe\MC64K\Defs\EffectiveAddress\IRegisterIndirect;
 class DisplacedIndirectEATest extends TestCase {
 
     const DISPLACEMENTS = [
-        '16'           => "\x10\x00\x00\x00",
-        '-1'           => "\xff\xff\xff\xff",
+        '16'           => "\x10",
+        '-1'           => "\xff",
     ];
 
     const NATIVE_TEST_CASE = [
-        '%s(%sr0)'  => IRegisterIndirect::R0_IND_DSP,
-        '%s(%sr1)'  => IRegisterIndirect::R1_IND_DSP,
-        '%s(%sr2)'  => IRegisterIndirect::R2_IND_DSP,
-        '%s(%sr3)'  => IRegisterIndirect::R3_IND_DSP,
-        '%s(%sr4)'  => IRegisterIndirect::R4_IND_DSP,
-        '%s(%sr5)'  => IRegisterIndirect::R5_IND_DSP,
-        '%s(%sr6)'  => IRegisterIndirect::R6_IND_DSP,
-        '%s(%sr7)'  => IRegisterIndirect::R7_IND_DSP,
-        '%s(%sr8)'  => IRegisterIndirect::R8_IND_DSP,
-        '%s(%sr9)'  => IRegisterIndirect::R9_IND_DSP,
-        '%s(%sr10)' => IRegisterIndirect::R10_IND_DSP,
-        '%s(%sr11)' => IRegisterIndirect::R11_IND_DSP,
-        '%s(%sr12)' => IRegisterIndirect::R12_IND_DSP,
-        '%s(%sr13)' => IRegisterIndirect::R13_IND_DSP,
-        '%s(%sr14)' => IRegisterIndirect::R14_IND_DSP,
-        '%s(%sr15)' => IRegisterIndirect::R15_IND_DSP,
+        '%s(%sr0)'  => IRegisterIndirect::R0_IND_DSP8,
+        '%s(%sr1)'  => IRegisterIndirect::R1_IND_DSP8,
+        '%s(%sr2)'  => IRegisterIndirect::R2_IND_DSP8,
+        '%s(%sr3)'  => IRegisterIndirect::R3_IND_DSP8,
+        '%s(%sr4)'  => IRegisterIndirect::R4_IND_DSP8,
+        '%s(%sr5)'  => IRegisterIndirect::R5_IND_DSP8,
+        '%s(%sr6)'  => IRegisterIndirect::R6_IND_DSP8,
+        '%s(%sr7)'  => IRegisterIndirect::R7_IND_DSP8,
+        '%s(%sr8)'  => IRegisterIndirect::R8_IND_DSP8,
+        '%s(%sr9)'  => IRegisterIndirect::R9_IND_DSP8,
+        '%s(%sr10)' => IRegisterIndirect::R10_IND_DSP8,
+        '%s(%sr11)' => IRegisterIndirect::R11_IND_DSP8,
+        '%s(%sr12)' => IRegisterIndirect::R12_IND_DSP8,
+        '%s(%sr13)' => IRegisterIndirect::R13_IND_DSP8,
+        '%s(%sr14)' => IRegisterIndirect::R14_IND_DSP8,
+        '%s(%sr15)' => IRegisterIndirect::R15_IND_DSP8,
     ];
 
     const LEGACY_TEST_CASE = [
-        '%s(%sa0)' => IRegisterIndirect::R8_IND_DSP,
-        '%s(%sa1)' => IRegisterIndirect::R9_IND_DSP,
-        '%s(%sa2)' => IRegisterIndirect::R10_IND_DSP,
-        '%s(%sa3)' => IRegisterIndirect::R11_IND_DSP,
-        '%s(%sa4)' => IRegisterIndirect::R12_IND_DSP,
-        '%s(%sa5)' => IRegisterIndirect::R13_IND_DSP,
-        '%s(%sa6)' => IRegisterIndirect::R14_IND_DSP,
-        '%s(%sa7)' => IRegisterIndirect::R15_IND_DSP,
-        '%s(%ssp)' => IRegisterIndirect::R15_IND_DSP,
+        '%s(%sa0)' => IRegisterIndirect::R8_IND_DSP8,
+        '%s(%sa1)' => IRegisterIndirect::R9_IND_DSP8,
+        '%s(%sa2)' => IRegisterIndirect::R10_IND_DSP8,
+        '%s(%sa3)' => IRegisterIndirect::R11_IND_DSP8,
+        '%s(%sa4)' => IRegisterIndirect::R12_IND_DSP8,
+        '%s(%sa5)' => IRegisterIndirect::R13_IND_DSP8,
+        '%s(%sa6)' => IRegisterIndirect::R14_IND_DSP8,
+        '%s(%sa7)' => IRegisterIndirect::R15_IND_DSP8,
+        '%s(%ssp)' => IRegisterIndirect::R15_IND_DSP8,
     ];
 
     /**

--- a/core/src/cpp/include/bytecode/effective_address.hpp
+++ b/core/src/cpp/include/bytecode/effective_address.hpp
@@ -30,21 +30,23 @@ namespace MC64K::ByteCode::EffectiveAddress {
  * Enumerates the base offsets for each Effective Address Type
  */
 enum Group {
-    OFS_GPR_DIR          = 0,   // GPR Direct r<N>
-    OFS_GPR_IND          = OFS_GPR_DIR          + 16,  // GPR Indirect (r<N>)
-    OFS_GPR_IND_POST_INC = OFS_GPR_IND          + 16,  // GPR Indirect, Post Increment (r<N>)+
-    OFS_GPR_IND_POST_DEC = OFS_GPR_IND_POST_INC + 16,  // GPR Indirect, Post Decrement (r<N>)-
-    OFS_GPR_IND_PRE_INC  = OFS_GPR_IND_POST_DEC + 16,  // GPR Indirect, Pre Increment +(r<N>)
-    OFS_GPR_IND_PRE_DEC  = OFS_GPR_IND_PRE_INC  + 16,  // GPR Indirect, Pre Decrement -(r<N>)
-    OFS_GPR_IND_DSP      = OFS_GPR_IND_PRE_DEC  + 16,  // GPR Indirect with Displacement <d32>(r<N>) / (<d32>, r<N>)
-    OFS_FPR_DIR          = OFS_GPR_IND_DSP      + 16, // FPR Direct fp<N>
-    OFS_GPR_IDX          = OFS_FPR_DIR          + 16, // GPR Indexed (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-    OFS_GPR_IDX_DSP      = OFS_GPR_IDX          + 16, // GPR Indexed with Displacement <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-    OFS_OTHER            = OFS_GPR_IDX_DSP      + 16,
-    OFS_OTHER_2          = OFS_OTHER            + 16,
+    OFS_GPR_DIR          = 0,                         // r<N>
+    OFS_GPR_IND          = OFS_GPR_DIR          + 16, // (r<N>)
+    OFS_GPR_IND_POST_INC = OFS_GPR_IND          + 16, // (r<N>)+
+    OFS_GPR_IND_POST_DEC = OFS_GPR_IND_POST_INC + 16, // (r<N>)-
+    OFS_GPR_IND_PRE_INC  = OFS_GPR_IND_POST_DEC + 16, // +(r<N>)
+    OFS_GPR_IND_PRE_DEC  = OFS_GPR_IND_PRE_INC  + 16, // -(r<N>)
+    OFS_GPR_IND_DSP8     = OFS_GPR_IND_PRE_DEC  + 16, // <d8>(r<N>) / (<d8>, r<N>)
+    OFS_GPR_IND_DSP      = OFS_GPR_IND_DSP8     + 16, // <d32>(r<N>) / (<d32>, r<N>)
+    OFS_FPR_DIR          = OFS_GPR_IND_DSP      + 16, // fp<N>
+    OFS_GPR_IDX          = OFS_FPR_DIR          + 16, // (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_GPR_IDX_DSP8     = OFS_GPR_IDX          + 16, // <d8>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_GPR_IDX_DSP      = OFS_GPR_IDX_DSP8     + 16, // <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_OTHER            = OFS_GPR_IDX_DSP      + 16, // Sundry 1
+    OFS_OTHER_2          = OFS_OTHER            + 16, // Sundry 2
 
-    OFS_PC_IND_IDX       = OFS_OTHER_2          + 16, // PC Indirect, indexed  (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
-    OFS_PC_IND_IDX_DSP   = OFS_PC_IND_IDX       + 16, // PC Indirect, indeced with displacement  <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_PC_IND_IDX       = OFS_OTHER_2          + 16, // (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_PC_IND_IDX_DSP   = OFS_PC_IND_IDX       + 16, // <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
 };
 
 /**

--- a/core/src/cpp/include/bytecode/effective_address.hpp
+++ b/core/src/cpp/include/bytecode/effective_address.hpp
@@ -31,21 +31,20 @@ namespace MC64K::ByteCode::EffectiveAddress {
  */
 enum Group {
     OFS_GPR_DIR          = 0,   // GPR Direct r<N>
-    OFS_GPR_IND          = 16,  // GPR Indirect (r<N>)
-    OFS_GPR_IND_POST_INC = 32,  // GPR Indirect, Post Increment (r<N>)+
-    OFS_GPR_IND_POST_DEC = 48,  // GPR Indirect, Post Decrement (r<N>)-
-    OFS_GPR_IND_PRE_INC  = 64,  // GPR Indirect, Pre Increment +(r<N>)
-    OFS_GPR_IND_PRE_DEC  = 80,  // GPR Indirect, Pre Decrement -(r<N>)
-    OFS_GPR_IND_DSP      = 96,  // GPR Indirect with Displacement <d32>(r<N>) / (<d32>, r<N>)
-    OFS_FPR_DIR          = 112, // FPR Direct fp<N>
-    OFS_GPR_IDX          = 128, // GPR Indexed (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-    OFS_GPR_IDX_DSP      = 144, // GPR Indexed with Displacement <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
-    OFS_OTHER            = 160,
-    OFS_OTHER_2          = 176,
+    OFS_GPR_IND          = OFS_GPR_DIR          + 16,  // GPR Indirect (r<N>)
+    OFS_GPR_IND_POST_INC = OFS_GPR_IND          + 16,  // GPR Indirect, Post Increment (r<N>)+
+    OFS_GPR_IND_POST_DEC = OFS_GPR_IND_POST_INC + 16,  // GPR Indirect, Post Decrement (r<N>)-
+    OFS_GPR_IND_PRE_INC  = OFS_GPR_IND_POST_DEC + 16,  // GPR Indirect, Pre Increment +(r<N>)
+    OFS_GPR_IND_PRE_DEC  = OFS_GPR_IND_PRE_INC  + 16,  // GPR Indirect, Pre Decrement -(r<N>)
+    OFS_GPR_IND_DSP      = OFS_GPR_IND_PRE_DEC  + 16,  // GPR Indirect with Displacement <d32>(r<N>) / (<d32>, r<N>)
+    OFS_FPR_DIR          = OFS_GPR_IND_DSP      + 16, // FPR Direct fp<N>
+    OFS_GPR_IDX          = OFS_FPR_DIR          + 16, // GPR Indexed (r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_GPR_IDX_DSP      = OFS_GPR_IDX          + 16, // GPR Indexed with Displacement <d32>(r<N>, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_OTHER            = OFS_GPR_IDX_DSP      + 16,
+    OFS_OTHER_2          = OFS_OTHER            + 16,
 
-    OFS_PC_IND_IDX       = 192, // PC Indirect, indexed  (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
-    OFS_PC_IND_IDX_DSP   = 298, // PC Indirect, indeced with displacement  <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
-
+    OFS_PC_IND_IDX       = OFS_OTHER_2          + 16, // PC Indirect, indexed  (pc, r<N>.<b|w|l|q> [ * <2|4|8>])
+    OFS_PC_IND_IDX_DSP   = OFS_PC_IND_IDX       + 16, // PC Indirect, indeced with displacement  <d32>(pc, r<N>.<b|w|l|q> [ * <2|4|8>])
 };
 
 /**

--- a/core/src/cpp/include/machine/gnarly.hpp
+++ b/core/src/cpp/include/machine/gnarly.hpp
@@ -45,6 +45,8 @@
     auBytes[3] = *puProgramCounter++;
 #endif
 
+#define readByteDisplacement() iDisplacement = ((int8)*puProgramCounter++);
+
 /**
  * Alias of readDisplacment() for when the value represents a mask value and not a displacement.
  */

--- a/docs/bytecode/ea/p_07.md
+++ b/docs/bytecode/ea/p_07.md
@@ -2,7 +2,7 @@
 
 ## General Purpose Register Indirect with Displacement
 
-The contents of the register, plus the signed 32-bit displacement are used as the address of the operand data in memory.
+The contents of the register, plus the signed 8 or 32-bit displacement are used as the address of the operand data in memory.
 
 General syntax: `<D>(r<N>)` or `(<D>, r<N>)`
 
@@ -35,14 +35,19 @@ Examples:
 * Allowed register names: r0 ... r15, a0 ... a7, sp
 * All bits of the register are used.
 * D = -2147483648 ... 2147483647
+* For values of D in the range -128 to 127, the displacement is stored as an 8 bit value.
 * Binary, Octal, Decimal and Hexadecimal displacements are allowed.
     - Only decimal values accept a sign.
 
 | Mode | Bytecode | Ext 0 | Ext 1  | Ext 2 | Ext 3 |
 | - | - | - | - | - | - |
-| `(r0)` | R0_IND_DSP | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `(r1)` | R1_IND_DSP | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D8>(r0)` | R0_IND_DSP8 | 0x*DD* |  |  |  |
+| `<D8>(r1)` | R1_IND_DSP8 | 0x*DD* |  |  |  |
+| ... | ... | ... |  |  |  |
+| `<D8>(r1)` | R15_IND_DSP8 | 0x*DD* |  |  |  |
+| `<D32>(r0)` | R0_IND_DSP | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r1)` | R1_IND_DSP | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
 | ... | ... | ... | ... | ... | ... |
-| `(r15)` | R15_IND_DSP | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r15)` | R15_IND_DSP | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
 
 [<< General Purpose Register Indirect, Pre Decrement](./p_06.md) | [Floating Point Register Direct >>](./p_08.md)

--- a/docs/bytecode/ea/p_10.md
+++ b/docs/bytecode/ea/p_10.md
@@ -2,7 +2,7 @@
 
 ## General Purpose Register Indirect with (Scaled) Index and Displacement
 
-The contents of the register, plus an optionally scaled index value taken from a second register, plus the signed 32-bit displacement are used as the address of the operand in memory. The index size and scale factor are selectable.
+The contents of the register, plus an optionally scaled index value taken from a second register, plus the signed 8 or 32-bit displacement are used as the address of the operand in memory. The index size and scale factor are selectable.
 
 General syntax: `<D>(r<A>, r<I>.<b|w|l|q> [ * <2|4|8>])` or `(<D>, r<A>, r<I>.<b|w|l|q> [ * <2|4|8>])`
 
@@ -38,24 +38,43 @@ Examples:
 * For .b, .w and .l sized indexes, the register fragment is treated as a signed value:
     - For a .b index, a register value of 0x00000000000000FF is interpreted as -1, not 255.
 * D = -2147483648 ... 2147483647
+* For values of D in the range -128 to 127, the displacement is stored as an 8 bit value.
+* Binary, Octal, Decimal and Hexadecimal displacements are allowed.
+    - Only decimal values accept a sign.
 
 | Mode | Bytecode | Ext 0 | Ext 1  | Ext 2 | Ext 3 | Ext 4 |
 | - | - | - | - | - | - | - |
-| `<D>(r<A>, r<I>.b)` | REG_IND_IDXB_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.w)` | REG_IND_IDXW_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.l)` | REG_IND_IDXL_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.q)` | REG_IND_IDXQ_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.b * 2)` | REG_IND_IDXB_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.w * 2)` | REG_IND_IDXW_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.l * 2)` | REG_IND_IDXL_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.q * 2)` | REG_IND_IDXQ_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.b * 4)` | REG_IND_IDXB_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.w * 4)` | REG_IND_IDXW_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.l * 4)` | REG_IND_IDXL_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.q * 4)` | REG_IND_IDXQ_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.b * 8)` | REG_IND_IDXB_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.w * 8)` | REG_IND_IDXW_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.l * 8)` | REG_IND_IDXL_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
-| `<D>(r<A>, r<I>.q * 8)` | REG_IND_IDXQ_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D8>(r<A>, r<I>.b)` | REG_IND_IDXB_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.w)` | REG_IND_IDXW_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.l)` | REG_IND_IDXL_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.q)` | REG_IND_IDXQ_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.b * 2)` | REG_IND_IDXB_2_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.w * 2)` | REG_IND_IDXW_2_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.l * 2)` | REG_IND_IDXL_2_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.q * 2)` | REG_IND_IDXQ_2_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.b * 4)` | REG_IND_IDXB_4_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.w * 4)` | REG_IND_IDXW_4_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.l * 4)` | REG_IND_IDXL_4_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.q * 4)` | REG_IND_IDXQ_4_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.b * 8)` | REG_IND_IDXB_8_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.w * 8)` | REG_IND_IDXW_8_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.l * 8)` | REG_IND_IDXL_8_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D8>(r<A>, r<I>.q * 8)` | REG_IND_IDXQ_8_DSP8 | 0x*AI* | 0x*DD* |  |  |  |
+| `<D32>(r<A>, r<I>.b)` | REG_IND_IDXB_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.w)` | REG_IND_IDXW_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.l)` | REG_IND_IDXL_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.q)` | REG_IND_IDXQ_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.b * 2)` | REG_IND_IDXB_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.w * 2)` | REG_IND_IDXW_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.l * 2)` | REG_IND_IDXL_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.q * 2)` | REG_IND_IDXQ_2_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.b * 4)` | REG_IND_IDXB_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.w * 4)` | REG_IND_IDXW_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.l * 4)` | REG_IND_IDXL_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.q * 4)` | REG_IND_IDXQ_4_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.b * 8)` | REG_IND_IDXB_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.w * 8)` | REG_IND_IDXW_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.l * 8)` | REG_IND_IDXL_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
+| `<D32>(r<A>, r<I>.q * 8)` | REG_IND_IDXQ_8_DSP | 0x*AI* | 0x*DD* | 0x*DD* | 0x*DD* | 0x*DD* |
 
 [<< General Purpose Register Indirect with (Scaled) Index](./p_9.md) | [Integer Immediate >>](./p_11.md)


### PR DESCRIPTION
Allows the use of 8 bit signed displacements for GPR indirect `<D>(Rn)` and indexed `<D>(Rn, Rs*S)` modes.