### PR TITLE
Fast path for conditional branching with register operands

### DIFF
--- a/assembler/src/parser/source_line/instruction/FastPathOptimiser.php
+++ b/assembler/src/parser/source_line/instruction/FastPathOptimiser.php
@@ -265,6 +265,10 @@ class FastPathOptimiser {
         return $sBytecode;
     }
 
+    private function handleBMC(int $iOpcode, string $sOperandByteCode): void {
+
+    }
+
     /**
      * BDC R2R fast path instruction size is one byte smaller. We need to account for that
      * when optimising both backwards branches and the stored reference to unresolved forwards ones.

--- a/assembler/src/parser/source_line/instruction/operand_set/IntegerMonadicBranch.php
+++ b/assembler/src/parser/source_line/instruction/operand_set/IntegerMonadicBranch.php
@@ -22,7 +22,7 @@ use ABadCafe\MC64K\Parser\EffectiveAddress;
 use ABadCafe\MC64K\Parser;
 use ABadCafe\MC64K\Defs\Mnemonic\IControl;
 use ABadCafe\MC64K\Defs\Mnemonic\ICondition;
-
+use ABadCafe\MC64K\Defs\EffectiveAddress\IRegisterDirect;
 use function \array_keys;
 
 /**
@@ -36,22 +36,22 @@ class IntegerMonadicBranch extends MonadicBranch {
      * Map of opcode keys to test functions for resolving immediate branches taken or not.
      */
     const OPCODES = [
-        IControl::BMC << 8 | ICondition::IEQ_B => 'foldIsZero',
-        IControl::BMC << 8 | ICondition::IEQ_W => 'foldIsZero',
-        IControl::BMC << 8 | ICondition::IEQ_L => 'foldIsZero',
-        IControl::BMC << 8 | ICondition::IEQ_Q => 'foldIsZero',
-        IControl::BMC << 8 | ICondition::INE_B => 'foldIsNotZero',
-        IControl::BMC << 8 | ICondition::INE_W => 'foldIsNotZero',
-        IControl::BMC << 8 | ICondition::INE_L => 'foldIsNotZero',
-        IControl::BMC << 8 | ICondition::INE_Q => 'foldIsNotZero',
-        IControl::BMC << 8 | ICondition::ILT_B => 'foldIsMinus',
-        IControl::BMC << 8 | ICondition::ILT_W => 'foldIsMinus',
-        IControl::BMC << 8 | ICondition::ILT_L => 'foldIsMinus',
-        IControl::BMC << 8 | ICondition::ILT_Q => 'foldIsMinus',
-        IControl::BMC << 8 | ICondition::IGT_B => 'foldIsPlus',
-        IControl::BMC << 8 | ICondition::IGT_W => 'foldIsPlus',
-        IControl::BMC << 8 | ICondition::IGT_L => 'foldIsPlus',
-        IControl::BMC << 8 | ICondition::IGT_Q => 'foldIsPlus',
+        IControl::BIZ_B => 'foldIsZero',
+        IControl::BIZ_W => 'foldIsZero',
+        IControl::BIZ_L => 'foldIsZero',
+        IControl::BIZ_Q => 'foldIsZero',
+        IControl::BNZ_B => 'foldIsNotZero',
+        IControl::BNZ_W => 'foldIsNotZero',
+        IControl::BNZ_L => 'foldIsNotZero',
+        IControl::BNZ_Q => 'foldIsNotZero',
+        IControl::BMI_B => 'foldIsMinus',
+        IControl::BMI_W => 'foldIsMinus',
+        IControl::BMI_L => 'foldIsMinus',
+        IControl::BMI_Q => 'foldIsMinus',
+        IControl::BPL_B => 'foldIsPlus',
+        IControl::BPL_W => 'foldIsPlus',
+        IControl::BPL_L => 'foldIsPlus',
+        IControl::BPL_Q => 'foldIsPlus',
     ];
 
     /**
@@ -67,6 +67,25 @@ class IntegerMonadicBranch extends MonadicBranch {
      */
     public function getOpcodes(): array {
         return array_keys(self::OPCODES);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(int $iOpcode, array $aOperands, array $aSizes = []): string {
+        $sBytecode = parent::parse($iOpcode, $aOperands, $aSizes);
+        if (
+            !empty($sBytecode) &&
+            ord($sBytecode[0]) <= IRegisterDirect::R15_DIR
+        ) {
+            throw new CodeFoldException(
+                "Integer Register Fast Path",
+                chr(IControl::R_BMC) .
+                chr($iOpcode & 0xFF) .
+                $sBytecode
+            );
+        }
+        return $sBytecode;
     }
 
     /**

--- a/core/src/cpp/include/machine/gnarly.hpp
+++ b/core/src/cpp/include/machine/gnarly.hpp
@@ -36,7 +36,7 @@
  */
 #ifdef ALLOW_MISALIGNED_IMMEDIATE
 #define readDisplacement() \
-    iDisplacement = *((int32*)puProgramCounter); puProgramCounter += sizeof(int32);
+    iDisplacement = *((int32 const*)puProgramCounter); puProgramCounter += sizeof(int32);
 #else
 #define readDisplacement() \
     auBytes[0] = *puProgramCounter++; \
@@ -147,6 +147,12 @@
 #define dstGPRLong()   aoGPR[uRegPair & 0x0F].iLong
 #define srcGPRLong()   aoGPR[uRegPair >> 4].iLong
 
+#define dstGPRUByte()   aoGPR[uRegPair & 0x0F].uByte
+#define srcGPRUByte()   aoGPR[uRegPair & 0x0F].uByte
+
+#define dstGPRUWord()   aoGPR[uRegPair & 0x0F].uWord
+#define srcGPRUWord()   aoGPR[uRegPair >> 4].uWord
+
 #define dstGPRULong()  aoGPR[uRegPair & 0x0F].uLong
 #define srcGPRULong()  aoGPR[uRegPair >> 4].uLong
 
@@ -167,6 +173,8 @@
 
 #define dstFPRUQuad()  aoFPR[uRegPair & 0x0F].uBinary
 #define srcFPRUQuad()  aoFPR[uRegPair >> 4].uBinary
+
+#define srcBitPos(m) (1 << (aoGPR[uRegPair & 0x0F].uByte & (m)))
 
 /**
  * Unpack a byte as a dest/src FPR pair and set the EA pointers directly.

--- a/core/src/cpp/machine/interpreter_bdc.cpp
+++ b/core/src/cpp/machine/interpreter_bdc.cpp
@@ -110,82 +110,85 @@ void NOINLINE Interpreter::handleBDC() {
 void NOINLINE Interpreter::handleR2RBDC() {
     using namespace MC64K::ByteCode;
     initDisplacement();
-    switch (*puProgramCounter++) {
+    uint8 uCase = *puProgramCounter++;
+    readRegPair();
+    readDisplacement();
+    switch (uCase) {
         // beq/fbeq
-        case Opcode::IEQ_B: unpackGPRPair(); readDisplacement(); bcc(asByte(pSrcEA)   == asByte(pDstEA));   return;
-        case Opcode::IEQ_W: unpackGPRPair(); readDisplacement(); bcc(asWord(pSrcEA)   == asWord(pDstEA));   return;
-        case Opcode::IEQ_L: unpackGPRPair(); readDisplacement(); bcc(asLong(pSrcEA)   == asLong(pDstEA));   return;
-        case Opcode::IEQ_Q: unpackGPRPair(); readDisplacement(); bcc(asQuad(pSrcEA)   == asQuad(pDstEA));   return;
-        case Opcode::FEQ_S: unpackFPRPair(); readDisplacement(); bcc(asSingle(pSrcEA) == asSingle(pDstEA)); return;
-        case Opcode::FEQ_D: unpackFPRPair(); readDisplacement(); bcc(asDouble(pSrcEA) == asDouble(pDstEA)); return;
+        case Opcode::IEQ_B: bcc(srcGPRByte()   == dstGPRByte());   return;
+        case Opcode::IEQ_W: bcc(srcGPRWord()   == dstGPRWord());   return;
+        case Opcode::IEQ_L: bcc(srcGPRLong()   == dstGPRLong());   return;
+        case Opcode::IEQ_Q: bcc(srcGPRQuad()   == dstGPRQuad());   return;
+        case Opcode::FEQ_S: bcc(srcFPRSingle() == dstFPRSingle()); return;
+        case Opcode::FEQ_D: bcc(srcFPRDouble() == dstFPRDouble()); return;
 
         // bne/fbne
-        case Opcode::INE_B: unpackGPRPair(); readDisplacement(); bcc(asByte(pSrcEA)   != asByte(pDstEA));   return;
-        case Opcode::INE_W: unpackGPRPair(); readDisplacement(); bcc(asWord(pSrcEA)   != asWord(pDstEA));   return;
-        case Opcode::INE_L: unpackGPRPair(); readDisplacement(); bcc(asLong(pSrcEA)   != asLong(pDstEA));   return;
-        case Opcode::INE_Q: unpackGPRPair(); readDisplacement(); bcc(asQuad(pSrcEA)   != asQuad(pDstEA));   return;
-        case Opcode::FNE_S: unpackFPRPair(); readDisplacement(); bcc(asSingle(pSrcEA) != asSingle(pDstEA)); return;
-        case Opcode::FNE_D: unpackFPRPair(); readDisplacement(); bcc(asDouble(pSrcEA) != asDouble(pDstEA)); return;
+        case Opcode::INE_B: bcc(srcGPRByte()   != dstGPRByte());   return;
+        case Opcode::INE_W: bcc(srcGPRWord()   != dstGPRWord());   return;
+        case Opcode::INE_L: bcc(srcGPRLong()   != dstGPRLong());   return;
+        case Opcode::INE_Q: bcc(srcGPRQuad()   != dstGPRQuad());   return;
+        case Opcode::FNE_S: bcc(srcFPRSingle() != dstFPRSingle()); return;
+        case Opcode::FNE_D: bcc(srcFPRDouble() != dstFPRDouble()); return;
 
         // blo/blt/fblt
-        case Opcode::ILT_B: unpackGPRPair(); readDisplacement(); bcc(asByte(pSrcEA)   < asByte(pDstEA));    return;
-        case Opcode::ILT_W: unpackGPRPair(); readDisplacement(); bcc(asWord(pSrcEA)   < asWord(pDstEA));    return;
-        case Opcode::ILT_L: unpackGPRPair(); readDisplacement(); bcc(asLong(pSrcEA)   < asLong(pDstEA));    return;
-        case Opcode::ILT_Q: unpackGPRPair(); readDisplacement(); bcc(asQuad(pSrcEA)   < asQuad(pDstEA));    return;
-        case Opcode::ULT_B: unpackGPRPair(); readDisplacement(); bcc(asUByte(pSrcEA)  < asUByte(pDstEA));   return;
-        case Opcode::ULT_W: unpackGPRPair(); readDisplacement(); bcc(asUWord(pSrcEA)  < asUWord(pDstEA));   return;
-        case Opcode::ULT_L: unpackGPRPair(); readDisplacement(); bcc(asULong(pSrcEA)  < asULong(pDstEA));   return;
-        case Opcode::ULT_Q: unpackGPRPair(); readDisplacement(); bcc(asUQuad(pSrcEA)  < asUQuad(pDstEA));   return;
-        case Opcode::FLT_S: unpackFPRPair(); readDisplacement(); bcc(asSingle(pSrcEA) < asSingle(pDstEA));  return;
-        case Opcode::FLT_D: unpackFPRPair(); readDisplacement(); bcc(asDouble(pSrcEA) < asDouble(pDstEA));  return;
+        case Opcode::ILT_B: bcc(srcGPRByte()   < dstGPRByte());    return;
+        case Opcode::ILT_W: bcc(srcGPRWord()   < dstGPRWord());    return;
+        case Opcode::ILT_L: bcc(srcGPRLong()   < dstGPRLong());    return;
+        case Opcode::ILT_Q: bcc(srcGPRQuad()   < dstGPRQuad());    return;
+        case Opcode::ULT_B: bcc(srcGPRUByte()  < dstGPRUByte());    return;
+        case Opcode::ULT_W: bcc(srcGPRUWord()  < dstGPRUWord());    return;
+        case Opcode::ULT_L: bcc(srcGPRULong()  < dstGPRULong());    return;
+        case Opcode::ULT_Q: bcc(srcGPRUQuad()  < dstGPRUQuad());    return;
+        case Opcode::FLT_S: bcc(srcFPRSingle() < dstFPRSingle());  return;
+        case Opcode::FLT_D: bcc(srcFPRDouble() < dstFPRDouble());  return;
 
         // bls/ble/fble
-        case Opcode::ILE_B: unpackGPRPair(); readDisplacement(); bcc(asByte(pSrcEA)   <= asByte(pDstEA));   return;
-        case Opcode::ILE_W: unpackGPRPair(); readDisplacement(); bcc(asWord(pSrcEA)   <= asWord(pDstEA));   return;
-        case Opcode::ILE_L: unpackGPRPair(); readDisplacement(); bcc(asLong(pSrcEA)   <= asLong(pDstEA));   return;
-        case Opcode::ILE_Q: unpackGPRPair(); readDisplacement(); bcc(asQuad(pSrcEA)   <= asQuad(pDstEA));   return;
-        case Opcode::ULE_B: unpackGPRPair(); readDisplacement(); bcc(asUByte(pSrcEA)  <= asUByte(pDstEA));  return;
-        case Opcode::ULE_W: unpackGPRPair(); readDisplacement(); bcc(asUWord(pSrcEA)  <= asUWord(pDstEA));  return;
-        case Opcode::ULE_L: unpackGPRPair(); readDisplacement(); bcc(asULong(pSrcEA)  <= asULong(pDstEA));  return;
-        case Opcode::ULE_Q: unpackGPRPair(); readDisplacement(); bcc(asUQuad(pSrcEA)  <= asUQuad(pDstEA));  return;
-        case Opcode::FLE_S: unpackFPRPair(); readDisplacement(); bcc(asSingle(pSrcEA) <= asSingle(pDstEA)); return;
-        case Opcode::FLE_D: unpackFPRPair(); readDisplacement(); bcc(asDouble(pSrcEA) <= asDouble(pDstEA)); return;
+        case Opcode::ILE_B: bcc(srcGPRByte()   <= dstGPRByte());   return;
+        case Opcode::ILE_W: bcc(srcGPRWord()   <= dstGPRWord());   return;
+        case Opcode::ILE_L: bcc(srcGPRLong()   <= dstGPRLong());   return;
+        case Opcode::ILE_Q: bcc(srcGPRQuad()   <= dstGPRQuad());   return;
+        case Opcode::ULE_B: bcc(srcGPRUByte()  <= dstGPRUByte());  return;
+        case Opcode::ULE_W: bcc(srcGPRUWord()  <= dstGPRUWord());  return;
+        case Opcode::ULE_L: bcc(srcGPRULong()  <= dstGPRULong());  return;
+        case Opcode::ULE_Q: bcc(srcGPRUQuad()  <= dstGPRUQuad());  return;
+        case Opcode::FLE_S: bcc(srcFPRSingle() <= dstFPRSingle()); return;
+        case Opcode::FLE_D: bcc(srcFPRDouble() <= dstFPRDouble()); return;
 
         // bhs/bge/fbge
-        case Opcode::IGE_B: unpackGPRPair(); readDisplacement(); bcc(asByte(pSrcEA)   >= asByte(pDstEA));   return;
-        case Opcode::IGE_W: unpackGPRPair(); readDisplacement(); bcc(asWord(pSrcEA)   >= asWord(pDstEA));   return;
-        case Opcode::IGE_L: unpackGPRPair(); readDisplacement(); bcc(asLong(pSrcEA)   >= asLong(pDstEA));   return;
-        case Opcode::IGE_Q: unpackGPRPair(); readDisplacement(); bcc(asQuad(pSrcEA)   >= asQuad(pDstEA));   return;
-        case Opcode::UGE_B: unpackGPRPair(); readDisplacement(); bcc(asUByte(pSrcEA)  >= asUByte(pDstEA));  return;
-        case Opcode::UGE_W: unpackGPRPair(); readDisplacement(); bcc(asUWord(pSrcEA)  >= asUWord(pDstEA));  return;
-        case Opcode::UGE_L: unpackGPRPair(); readDisplacement(); bcc(asULong(pSrcEA)  >= asULong(pDstEA));  return;
-        case Opcode::UGE_Q: unpackGPRPair(); readDisplacement(); bcc(asUQuad(pSrcEA)  >= asUQuad(pDstEA));  return;
-        case Opcode::FGE_S: unpackFPRPair(); readDisplacement(); bcc(asSingle(pSrcEA) >= asSingle(pDstEA)); return;
-        case Opcode::FGE_D: unpackFPRPair(); readDisplacement(); bcc(asDouble(pSrcEA) >= asDouble(pDstEA)); return;
+        case Opcode::IGE_B: bcc(srcGPRByte()   >= dstGPRByte());   return;
+        case Opcode::IGE_W: bcc(srcGPRWord()   >= dstGPRWord());   return;
+        case Opcode::IGE_L: bcc(srcGPRLong()   >= dstGPRLong());   return;
+        case Opcode::IGE_Q: bcc(srcGPRQuad()   >= dstGPRQuad());   return;
+        case Opcode::UGE_B: bcc(srcGPRUByte()  >= dstGPRUByte());  return;
+        case Opcode::UGE_W: bcc(srcGPRUWord()  >= dstGPRUWord());  return;
+        case Opcode::UGE_L: bcc(srcGPRULong()  >= dstGPRULong());  return;
+        case Opcode::UGE_Q: bcc(srcGPRUQuad()  >= dstGPRUQuad());  return;
+        case Opcode::FGE_S: bcc(srcFPRSingle() >= dstFPRSingle()); return;
+        case Opcode::FGE_D: bcc(srcFPRDouble() >= dstFPRDouble()); return;
 
         // bhi/bgt/fbgt
-        case Opcode::IGT_B: unpackGPRPair(); readDisplacement(); bcc(asByte(pSrcEA)   > asByte(pDstEA));    return;
-        case Opcode::IGT_W: unpackGPRPair(); readDisplacement(); bcc(asWord(pSrcEA)   > asWord(pDstEA));    return;
-        case Opcode::IGT_L: unpackGPRPair(); readDisplacement(); bcc(asLong(pSrcEA)   > asLong(pDstEA));    return;
-        case Opcode::IGT_Q: unpackGPRPair(); readDisplacement(); bcc(asQuad(pSrcEA)   > asQuad(pDstEA));    return;
-        case Opcode::UGT_B: unpackGPRPair(); readDisplacement(); bcc(asUByte(pSrcEA)  > asUByte(pDstEA));   return;
-        case Opcode::UGT_W: unpackGPRPair(); readDisplacement(); bcc(asUWord(pSrcEA)  > asUWord(pDstEA));   return;
-        case Opcode::UGT_L: unpackGPRPair(); readDisplacement(); bcc(asULong(pSrcEA)  > asULong(pDstEA));   return;
-        case Opcode::UGT_Q: unpackGPRPair(); readDisplacement(); bcc(asUQuad(pSrcEA)  > asUQuad(pDstEA));   return;
-        case Opcode::FGT_S: unpackFPRPair(); readDisplacement(); bcc(asSingle(pSrcEA) > asSingle(pDstEA));  return;
-        case Opcode::FGT_D: unpackFPRPair(); readDisplacement(); bcc(asDouble(pSrcEA) > asDouble(pDstEA));  return;
+        case Opcode::IGT_B: bcc(srcGPRByte()   > dstGPRByte());    return;
+        case Opcode::IGT_W: bcc(srcGPRWord()   > dstGPRWord());    return;
+        case Opcode::IGT_L: bcc(srcGPRLong()   > dstGPRLong());    return;
+        case Opcode::IGT_Q: bcc(srcGPRQuad()   > dstGPRQuad());    return;
+        case Opcode::UGT_B: bcc(srcGPRUByte()  > dstGPRUByte());   return;
+        case Opcode::UGT_W: bcc(srcGPRUWord()  > dstGPRUWord());   return;
+        case Opcode::UGT_L: bcc(srcGPRULong()  > dstGPRULong());   return;
+        case Opcode::UGT_Q: bcc(srcGPRUQuad()  > dstGPRUQuad());   return;
+        case Opcode::FGT_S: bcc(srcFPRSingle() > dstFPRSingle());  return;
+        case Opcode::FGT_D: bcc(srcFPRDouble() > dstFPRDouble());  return;
 
         // Integer Bit position set
-        case Opcode::BPS_B: unpackGPRPair(); readDisplacement(); bcc(asUByte(pDstEA)   & asBitPos(pSrcEA, 7));  return;
-        case Opcode::BPS_W: unpackGPRPair(); readDisplacement(); bcc(asUWord(pDstEA)   & asBitPos(pSrcEA, 15)); return;
-        case Opcode::BPS_L: unpackGPRPair(); readDisplacement(); bcc(asULong(pDstEA)   & asBitPos(pSrcEA, 31)); return;
-        case Opcode::BPS_Q: unpackGPRPair(); readDisplacement(); bcc(asUQuad(pDstEA)   & asBitPos(pSrcEA, 63)); return;
+        case Opcode::BPS_B: bcc(dstGPRUByte()   & srcBitPos(7));  return;
+        case Opcode::BPS_W: bcc(dstGPRUWord()   & srcBitPos(15)); return;
+        case Opcode::BPS_L: bcc(dstGPRULong()   & srcBitPos(31)); return;
+        case Opcode::BPS_Q: bcc(dstGPRUQuad()   & srcBitPos(63)); return;
 
         // Integer Bit position clear
-        case Opcode::BPC_B: unpackGPRPair(); readDisplacement(); bcc(!(asUByte(pDstEA) & asBitPos(pSrcEA, 7)));  return;
-        case Opcode::BPC_W: unpackGPRPair(); readDisplacement(); bcc(!(asUWord(pDstEA) & asBitPos(pSrcEA, 15))); return;
-        case Opcode::BPC_L: unpackGPRPair(); readDisplacement(); bcc(!(asULong(pDstEA) & asBitPos(pSrcEA, 31))); return;
-        case Opcode::BPC_Q: unpackGPRPair(); readDisplacement(); bcc(!(asUQuad(pDstEA) & asBitPos(pSrcEA, 63))); return;
+        case Opcode::BPC_B: bcc(!(dstGPRUByte() & srcBitPos(7)));  return;
+        case Opcode::BPC_W: bcc(!(dstGPRUWord() & srcBitPos(15))); return;
+        case Opcode::BPC_L: bcc(!(dstGPRULong() & srcBitPos(31))); return;
+        case Opcode::BPC_Q: bcc(!(dstGPRUQuad() & srcBitPos(63))); return;
 
         default:
             todo(); // will trigger an unimplemented opcode

--- a/core/src/cpp/machine/interpreter_bmc.cpp
+++ b/core/src/cpp/machine/interpreter_bmc.cpp
@@ -71,39 +71,41 @@ void NOINLINE Interpreter::handleBMC() {
 void NOINLINE Interpreter::handleRBMC() {
     using namespace MC64K::ByteCode;
     initDisplacement();
-
-    switch (*puProgramCounter++) {
+    uint8 uCase = *puProgramCounter++;
+    readRegPair();
+    readDisplacement();
+    switch (uCase) {
         // biz/fbiz
-        case Opcode::IEQ_B: unpackGPR(); readDisplacement(); bcc(!asByte(pDstEA)); return;
-        case Opcode::IEQ_W: unpackGPR(); readDisplacement(); bcc(!asWord(pDstEA)); return;
-        case Opcode::IEQ_L: unpackGPR(); readDisplacement(); bcc(!asLong(pDstEA)); return;
-        case Opcode::IEQ_Q: unpackGPR(); readDisplacement(); bcc(!asQuad(pDstEA)); return;
-        case Opcode::FEQ_S: unpackFPR(); readDisplacement(); bcc(!asSingle(pDstEA)); return;
-        case Opcode::FEQ_D: unpackFPR(); readDisplacement(); bcc(!asDouble(pDstEA)); return;
+        case Opcode::IEQ_B: bcc(!dstGPRByte());   return;
+        case Opcode::IEQ_W: bcc(!dstGPRWord());   return;
+        case Opcode::IEQ_L: bcc(!dstGPRLong());   return;
+        case Opcode::IEQ_Q: bcc(!dstGPRQuad());   return;
+        case Opcode::FEQ_S: bcc(!dstFPRSingle()); return;
+        case Opcode::FEQ_D: bcc(!dstFPRDouble()); return;
 
         // bnz/fbnz
-        case Opcode::INE_B: unpackGPR(); readDisplacement(); bcc(asByte(pDstEA)); return;
-        case Opcode::INE_W: unpackGPR(); readDisplacement(); bcc(asWord(pDstEA)); return;
-        case Opcode::INE_L: unpackGPR(); readDisplacement(); bcc(asLong(pDstEA)); return;
-        case Opcode::INE_Q: unpackGPR(); readDisplacement(); bcc(asQuad(pDstEA)); return;
-        case Opcode::FNE_S: unpackFPR(); readDisplacement(); bcc(asSingle(pDstEA)); return;
-        case Opcode::FNE_D: unpackFPR(); readDisplacement(); bcc(asDouble(pDstEA)); return;
+        case Opcode::INE_B: bcc(dstGPRByte());   return;
+        case Opcode::INE_W: bcc(dstGPRWord());   return;
+        case Opcode::INE_L: bcc(dstGPRLong());   return;
+        case Opcode::INE_Q: bcc(dstGPRQuad());   return;
+        case Opcode::FNE_S: bcc(dstFPRSingle()); return;
+        case Opcode::FNE_D: bcc(dstFPRDouble()); return;
 
         // bmi/fbmi
-        case Opcode::ILT_B: unpackGPR(); readDisplacement(); bcc(0 > asByte(pDstEA)); return;
-        case Opcode::ILT_W: unpackGPR(); readDisplacement(); bcc(0 > asWord(pDstEA)); return;
-        case Opcode::ILT_L: unpackGPR(); readDisplacement(); bcc(0 > asLong(pDstEA)); return;
-        case Opcode::ILT_Q: unpackGPR(); readDisplacement(); bcc(0 > asQuad(pDstEA)); return;
-        case Opcode::FLT_S: unpackFPR(); readDisplacement(); bcc(0 > asSingle(pDstEA)); return;
-        case Opcode::FLT_D: unpackFPR(); readDisplacement(); bcc(0 > asDouble(pDstEA)); return;
+        case Opcode::ILT_B: bcc(0 > dstGPRByte());   return;
+        case Opcode::ILT_W: bcc(0 > dstGPRWord());   return;
+        case Opcode::ILT_L: bcc(0 > dstGPRLong());   return;
+        case Opcode::ILT_Q: bcc(0 > dstGPRQuad());   return;
+        case Opcode::FLT_S: bcc(0 > dstFPRSingle()); return;
+        case Opcode::FLT_D: bcc(0 > dstFPRDouble()); return;
 
         // bpl/fbpl
-        case Opcode::IGT_B: unpackGPR(); readDisplacement(); bcc(0 < asByte(pDstEA)); return;
-        case Opcode::IGT_W: unpackGPR(); readDisplacement(); bcc(0 < asWord(pDstEA)); return;
-        case Opcode::IGT_L: unpackGPR(); readDisplacement(); bcc(0 < asLong(pDstEA)); return;
-        case Opcode::IGT_Q: unpackGPR(); readDisplacement(); bcc(0 < asQuad(pDstEA)); return;
-        case Opcode::FGT_S: unpackFPR(); readDisplacement(); bcc(0 < asSingle(pDstEA)); return;
-        case Opcode::FGT_D: unpackFPR(); readDisplacement(); bcc(0 < asDouble(pDstEA)); return;
+        case Opcode::IGT_B: bcc(0 < dstGPRByte());   return;
+        case Opcode::IGT_W: bcc(0 < dstGPRWord());   return;
+        case Opcode::IGT_L: bcc(0 < dstGPRLong());   return;
+        case Opcode::IGT_Q: bcc(0 < dstGPRQuad());   return;
+        case Opcode::FGT_S: bcc(0 < dstFPRSingle()); return;
+        case Opcode::FGT_D: bcc(0 < dstFPRDouble()); return;
 
         default:
             todo(); // will trigger an unimplemented opcode


### PR DESCRIPTION
Implemented fast path versions of compare and branch for register only operands:
- Affects all conditional types
- Affects all register sizes

Before:
```
Benchmarking: biz.q r0, label (when taken)
	took:   4148773853 nanoseconds 192.8281 MIPS 3.8924 relative
Benchmarking: biz.q r0, label (when not taken)
	took:   3927312225 nanoseconds 203.7017 MIPS 3.6846 relative
```
After
```
Benchmarking: biz.q r0, label (when taken)
	took:   2766896649 nanoseconds 289.1326 MIPS 2.6259 relative
Benchmarking: biz.q r0, label (when not taken)
	took:   2441081973 nanoseconds 327.7235 MIPS 2.3167 relative
```