### PR TITLE
Addd link/unlk to interpreter benchmarks

### DIFF
--- a/assembler/test_projects/bench/src/bench_link_unlk.s
+++ b/assembler/test_projects/bench/src/bench_link_unlk.s
@@ -1,0 +1,53 @@
+    @align  0, 8
+bench_link_unlk:
+
+    ; benchmarks forward branch/return
+    lea         .benchmark_info,    r8
+    hcf         io_print_string
+
+    move.q      max_loops,          loop_counter
+    nanotime
+    move.q      time_recorded,      time_started
+.benchmark_loop:
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    link        r5, #-64
+    unlk        r5
+
+    dbnz        loop_counter,       .benchmark_loop
+    nanotime
+    sub.q       calibration_time,   time_recorded
+    sub.q       time_started,       time_recorded
+    bsr         report_elapsed
+    bsr         report_relative
+.dummy:
+    rts
+
+.benchmark_info:
+    dc.b "Benchmarking: link r5, #-64/unlk r5\n\0"

--- a/core/src/cpp/Makefile.x64_baseline_linux
+++ b/core/src/cpp/Makefile.x64_baseline_linux
@@ -1,0 +1,34 @@
+# Project: MC64000
+
+# Target
+BIN      = bin/interpreter_x64
+
+# This sets the source file to use for the display context manager. Platform dependent.
+USE_DISP_CTX = x11
+
+# This seds the source file to use for the audio output device. Platform dependent.
+USE_AUDIO_OUT = alsa
+
+# Compiler settings
+CXXFLAGS = --std=c++17 -Wall -Wconversion -Werror -O2 -march=native -mtune=native -fPIC -pipe -Iinclude
+GCC_CXXFLAGS = -DMESSAGE='"Compiled with GCC"'
+CLANG_CXXFLAGS = -v -funroll-loops -DMESSAGE='"Compiled with Clang"'
+UNKNOWN_CXXFLAGS = -DMESSAGE='"Compiled with an unknown compiler"'
+
+# Needed libraries
+LIBS = -lX11 -lasound
+
+ifeq ($(CXX),g++)
+  GCC_EXTRA = -fwhole-program -flto
+  CXXFLAGS += $(GCC_CXXFLAGS) $(GCC_EXTRA)
+else ifeq ($(CXX),clang++)
+  CXXFLAGS += $(CLANG_CXXFLAGS)
+else
+  CXXFLAGS += $(UNKNOWN_CXXFLAGS)
+endif
+
+# Makefile settings
+ARCH     = x64_linux
+MEXT     = $(ARCH)
+
+include mc64k.make


### PR DESCRIPTION
Adds missing source file to the benchmark test for opcode throughput.
Adds missing baseline x64 makefile