### PR TITLE
Deduplicating FILTH opcode handlers

### DIFF
--- a/core/src/cpp/include/host/display/x11/filth/commands/palette.hpp
+++ b/core/src/cpp/include/host/display/x11/filth/commands/palette.hpp
@@ -1,0 +1,111 @@
+#ifdef FILTH_COMMAND_PALLETE
+
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+/**
+ * FILTH processor (switch/case) handlers for palette related commands
+ */
+
+case FC_SET_PALETTE: {
+    uint8 uIndex = *puCode++;
+    puPalette[uIndex] = getImmediate<uint32>(puCode);
+    puCode += sizeof(uint32);
+    break;
+}
+
+case FC_ADD_PALETTE_RGB: {
+    // todo - this sucks
+    uint8 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[0] += puCode[0];
+    ((uint8*)(&puPalette[uIndex]))[1] += puCode[1];
+    ((uint8*)(&puPalette[uIndex]))[2] += puCode[2];
+    puCode += sizeof(uint32);
+    break;
+}
+
+case FC_SUB_PALETTE_RGB: {
+    // todo - this sucks
+    uint8 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[0] -= puCode[0];
+    ((uint8*)(&puPalette[uIndex]))[1] -= puCode[1];
+    ((uint8*)(&puPalette[uIndex]))[2] -= puCode[2];
+    puCode += sizeof(uint32);
+    break;
+}
+
+case FC_SET_PALETTE_R: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[2] = *puCode++;
+    break;
+}
+
+case FC_ADD_PALETTE_R: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[2] += *puCode++;
+    break;
+}
+
+case FC_SUB_PALETTE_R: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[2] -= *puCode++;
+    break;
+}
+
+case FC_SET_PALETTE_G: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[1] = *puCode++;
+    break;
+}
+
+case FC_ADD_PALETTE_G: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[1] += *puCode++;
+    break;
+}
+
+case FC_SUB_PALETTE_G: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[1] -= *puCode++;
+    break;
+}
+
+case FC_SET_PALETTE_B: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[0] = *puCode++;
+    break;
+}
+
+case FC_ADD_PALETTE_B: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[0] += *puCode++;
+    break;
+}
+
+case FC_SUB_PALETTE_B: {
+    uint32 uIndex = *puCode++;
+    ((uint8*)(&puPalette[uIndex]))[0] -= *puCode++;
+    break;
+}
+
+case FC_SWP_PALETTE: {
+    uint8 uIndexA = *puCode++;
+    uint8 uIndexB = *puCode++;
+    uint32 uRGB = puPalette[uIndexA];
+    puPalette[uIndexA] = puPalette[uIndexB];
+    puPalette[uIndexB] = uRGB;
+    break;
+}
+
+#undef FILTH_COMMAND_PALLETE
+#endif

--- a/core/src/cpp/include/host/display/x11/filth/commands/selfmod.hpp
+++ b/core/src/cpp/include/host/display/x11/filth/commands/selfmod.hpp
@@ -1,0 +1,59 @@
+#ifdef FILTH_COMMAND_SELFMOD
+
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+/**
+ * FILTH processor (switch/case) handlers for script self-modification
+ *
+ * We can set, add and subtract values from given script offsets
+ */
+
+case FC_SET_BYTE:
+    puCode += setImmediate<uint8>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_SET_WORD:
+    puCode += setImmediate<uint16>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_SET_LONG:
+    puCode += setImmediate<uint32>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_ADD_BYTE:
+    puCode += addToImmediate<uint8>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_ADD_WORD:
+    puCode += addToImmediate<uint16>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_ADD_LONG:
+    puCode += addToImmediate<uint32>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_SUB_BYTE:
+    puCode += subFromImmediate<uint8>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_SUB_WORD:
+    puCode += subFromImmediate<uint16>(puCode, roContext.puFilthScript);
+    break;
+
+case FC_SUB_LONG:
+    puCode += subFromImmediate<uint32>(puCode, roContext.puFilthScript);
+    break;
+
+#undef FILTH_COMMAND_SELFMOD
+#endif

--- a/core/src/cpp/include/host/display/x11/filth/commands/view.hpp
+++ b/core/src/cpp/include/host/display/x11/filth/commands/view.hpp
@@ -1,0 +1,50 @@
+#ifdef FILTH_COMMAND_VIEW
+
+/**
+ *   888b     d888  .d8888b.   .d8888b.      d8888  888    d8P
+ *   8888b   d8888 d88P  Y88b d88P  Y88b    d8P888  888   d8P
+ *   88888b.d88888 888    888 888          d8P 888  888  d8P
+ *   888Y88888P888 888        888d888b.   d8P  888  888d88K
+ *   888 Y888P 888 888        888P "Y88b d88   888  8888888b
+ *   888  Y8P  888 888    888 888    888 8888888888 888  Y88b
+ *   888   "   888 Y88b  d88P Y88b  d88P       888  888   Y88b
+ *   888       888  "Y8888P"   "Y8888P"        888  888    Y88b
+ *
+ *    - 64-bit 680x0-inspired Virtual Machine and assembler -
+ */
+
+/**
+ * FILTH processor (switch/case) handlers for viewport related commands
+ */
+
+case FC_SET_VIEW_X:
+    uViewXOffset = getImmediate<uint16>(puCode);
+    puCode += sizeof(uint16);
+    break;
+
+case FC_ADD_VIEW_X:
+    uViewXOffset += getImmediate<uint16>(puCode);
+    puCode += sizeof(uint16);
+    break;
+
+case FC_SUB_VIEW_X:
+    uViewXOffset -= getImmediate<uint16>(puCode);
+    puCode += sizeof(uint16);
+    break;
+
+case FC_SET_VIEW_Y:
+    uViewYOffset = getImmediate<uint16>(puCode);
+    puCode += sizeof(uint16);
+    break;
+
+case FC_ADD_VIEW_Y:
+    uViewYOffset += getImmediate<uint16>(puCode);
+    puCode += sizeof(uint16);
+    break;
+
+case FC_SUB_VIEW_Y:
+    uViewYOffset -= getImmediate<uint16>(puCode);
+    puCode += sizeof(uint16);
+    break;
+
+#endif

--- a/core/src/cpp/include/host/display/x11/filth/generic.hpp
+++ b/core/src/cpp/include/host/display/x11/filth/generic.hpp
@@ -19,6 +19,9 @@
 
 namespace MC64K::StandardTestHost::Display::x11 {
 
+/**
+ * Updates the visible portion of an 8-bit surface.
+ */
 void* updateLUT8Generic(Context& roContext) {
     if (uint32 const* puPalette = roContext.puPalette) {
         uint32* pDst = (uint32*)roContext.puImageBuffer;
@@ -97,7 +100,9 @@ void* updateLUT8Generic(Context& roContext) {
     return roContext.puImageBuffer;
 }
 
-
+/**
+ * Updates the visible portion of a 32-bit surface.
+ */
 void* updateARGB32Generic(Context& roContext) {
 
     uint32* pDst = (uint32*)roContext.puImageBuffer;

--- a/core/src/cpp/include/host/display/x11/filth/script.hpp
+++ b/core/src/cpp/include/host/display/x11/filth/script.hpp
@@ -118,6 +118,7 @@ void* updateLUT8Filth(Context& roContext) {
                 }
                 filth_end:
                 // Calculate buffer location
+                // Yucky modulo to get the coordinates back into a sensible place.
                 uint32 xSrc = xDst + uViewXOffset;
                 if (xSrc > roContext.uBufferWidth) {
                     xSrc %= roContext.uBufferWidth;
@@ -182,6 +183,7 @@ void* updateARGB32Filth(Context& roContext) {
             }
             filth_end:
             // Calculate buffer location
+            // Yucky modulo to get the coordinates back into a sensible place.
             uint32 xSrc = xDst + uViewXOffset;
             if (xSrc > roContext.uBufferWidth) {
                 xSrc %= roContext.uBufferWidth;


### PR DESCRIPTION
Nothing clever, just moved the handlers for the cases into separate includes that allow each operation to have a single implementation in code, even if not in the actual binary.